### PR TITLE
Change coordinator base

### DIFF
--- a/.changeset/thirty-camels-think.md
+++ b/.changeset/thirty-camels-think.md
@@ -1,0 +1,5 @@
+---
+"@caravan/coordinator": patch
+---
+
+Change the baseUrl for caravan coordinator from /caravan/# to /coordinator/#

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 # Caravan Monorepo
 
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+![Build Status](https://github.com/caravan-bitcoin/caravan/actions/workflows/ci.yml/badge.svg)
+![Hosted Coordinator](https://github.com/caravan-bitcoin/caravan/actions/workflows/deploy.yml/badge.svg)
+![Package Publication](https://github.com/caravan-bitcoin/caravan/actions/workflows/release.yml/badge.svg)
+
 ## Introduction
 
 This is a monorepo project for the Caravan FOSS ecosystem, built with

--- a/apps/coordinator/README.md
+++ b/apps/coordinator/README.md
@@ -1,11 +1,5 @@
 # Caravan - Stateless Multisig Coordinator
 
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
-[![Build Status](https://travis-ci.com/unchained-capital/caravan.svg?branch=master)](https://travis-ci.com/unchained-capital/caravan)
-[![dependencies Status](https://david-dm.org/unchained-capital/caravan/status.svg)](https://david-dm.org/unchained-capital/caravan)
-[![devDependencies Status](https://david-dm.org/unchained-capital/caravan/dev-status.svg)](https://david-dm.org/unchained-capital/caravan?type=dev)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
-
 Caravan is making bitcoin multisig custody easier and safer through
 transparency and standards.
 
@@ -16,7 +10,7 @@ addresses.
 Caravan is also stateless. It does not itself store any data. You must
 safekeep the addresses (and redeem scripts & BIP32 paths) you create.
 
-[Try Caravan now!](https://unchained-capital.github.io/caravan)
+[Try Caravan now!](https://caravan-bitcoin.github.io/coordinator)
 
 ## Installation
 
@@ -26,7 +20,7 @@ be run in any web browser from a local or remote installation.
 ### Unchained Capital GitHub
 
 The simplest way to use Caravan is to visit
-[https://unchained-capital.github.io/caravan](https://unchained-capital.github.io/caravan),
+[https://caravan-bitcoin.github.io/coordinator](https://caravan-bitcoin.github.io/coordinator),
 a copy of Caravan hosted on GitHub by
 [Unchained Capital](https://www.unchained.com).
 
@@ -34,7 +28,7 @@ a copy of Caravan hosted on GitHub by
 
 If you would prefer to host your own copy of Caravan on GitHub, you
 can do so by first forking the
-[Caravan repository](https://github.com/unchained-capital/caravan)
+[Caravan repository](https://github.com/caravan-bitcoin/caravan)
 into your own GitHub organization. Go to the (newly forked) repository's "Settings" page and
 scroll down to the "GitHub Pages" section. Make sure to setup the settings
 to us a gh-pages branch (create the branch if necessary).
@@ -49,7 +43,7 @@ $ turbo run deploy
 ```
 
 You should see a copy of the Caravan web application at
-`https://YOUR_GITHUB_USERNAME.github.io/caravan`. If not, go back to the
+`https://YOUR_GITHUB_USERNAME.github.io/coordinator`. If not, go back to the
 GitHub Pages section and ensure you see a message
 saying "Your site is published at ...".
 
@@ -59,7 +53,7 @@ You can always clone the source code of Caravan to your local machine
 and run it from there. You will require a recent `npm` installation.
 
 ```bash
-$ git clone https://github.com/unchained-capital/caravan
+$ git clone https://github.com/caravan-bitcoin/caravan
 ...
 $ cd caravan
 $ npm install
@@ -68,7 +62,7 @@ $ npm run dev
 ...
 ```
 
-Now visit http://localhost:5173 to interact with your local copy of
+Now visit http://localhost:5173/coordinator/# to interact with your local copy of
 Caravan.
 
 ### Host Remotely
@@ -110,8 +104,8 @@ Caravan should then be accessible at http://localhost:8000/caravan/#
 
 ## Usage
 
-If you can access the [Caravan web
-application](https://unchained-capital.github.io/caravan) in your
+If you can access the [Caravan Coordinator web
+application](https://caravan-bitcoin.github.io/coordinator) in your
 browser, you are ready to start using Caravan.
 
 Click the _Create_ or _Interact_ links in the navbar to get started.
@@ -359,4 +353,4 @@ point that if corsproxy is running, paste your node's IP:port on the end of the
 
 ## Contributing
 
-Please see the [`CONTRIBUTING.md`](./CONTRIBUTING.md) and the open [GitHub Issues](https://github.com/unchained-capital/caravan/issues)
+Please see the [`CONTRIBUTING.md`](./CONTRIBUTING.md) and the open [GitHub Issues](https://github.com/caravan-bitcoin/caravan/issues)

--- a/apps/coordinator/src/components/ClientPicker/PrivateClientSettings.jsx
+++ b/apps/coordinator/src/components/ClientPicker/PrivateClientSettings.jsx
@@ -31,7 +31,7 @@ const PrivateClientSettings = ({
           "Due to CORS requirements, you must use a proxy around the node. Instructions are available "
         }
         {externalLink(
-          "https://github.com/unchained-capital/caravan#adding-cors-headers",
+          "https://github.com/caravan-bitcoin/caravan#adding-cors-headers",
           "here",
         )}
         {"."}

--- a/apps/coordinator/src/components/ErrorBoundary.tsx
+++ b/apps/coordinator/src/components/ErrorBoundary.tsx
@@ -2,7 +2,7 @@ import React, { ErrorInfo } from "react";
 
 import { Box, Typography } from "@mui/material";
 
-const reportingURL = "https://github.com/unchained-capital/caravan/issues";
+const reportingURL = "https://github.com/caravan-bitcoin/caravan/issues";
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;

--- a/apps/coordinator/src/components/Footer.tsx
+++ b/apps/coordinator/src/components/Footer.tsx
@@ -11,7 +11,7 @@ const Footer = () => (
     <Grid container justifyContent="space-between" alignItems="center">
       <Grid item sm={2}>
         {externalLink(
-          "https://www.unchained-capital.com",
+          "https://www.unchained.com",
           <img
             src={logo}
             className="logo"

--- a/apps/coordinator/src/components/Help.tsx
+++ b/apps/coordinator/src/components/Help.tsx
@@ -174,7 +174,7 @@ const Help = () => (
                   </ListItemIcon>
                   <ListItemText>
                     {externalLink(
-                      "https://unchained-capital.com/blog/gearing-up-the-caravan/",
+                      "https://unchained.com/blog/gearing-up-the-caravan/",
                       "Blog Post",
                     )}
                   </ListItemText>
@@ -198,7 +198,7 @@ const Help = () => (
                   </ListItemIcon>
                   <ListItemText>
                     {externalLink(
-                      "https://github.com/unchained-capital/caravan",
+                      "https://github.com/caravan-bitcoin/caravan",
                       "Source Code",
                     )}
                   </ListItemText>
@@ -261,7 +261,7 @@ const Help = () => (
               Seeing a bug or need a feature?
             </CardContent>
             <CardActions>
-              <Button href="https://github.com/unchained-capital/caravan/issues">
+              <Button href="https://github.com/caravan-bitcoin/caravan/issues">
                 <BugReport /> &nbsp; Report Issue
               </Button>
               <Button data-cy="run-tests-button" component={Link} to="/test">

--- a/apps/coordinator/vite.config.ts
+++ b/apps/coordinator/vite.config.ts
@@ -5,7 +5,7 @@ import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: "/caravan/#",
+  base: "/coordinator/#",
   resolve: {
     alias: {
       utils: path.resolve(__dirname, "./src/utils"),


### PR DESCRIPTION
With the base url now being `caravan-bitcoin` it felt a little redundant to keep the base for the coordinator app still be `caravan`. This PR changes the base path to be `coordinator/#`. This works out of the box if you try and run locally with `turbo run dev` and then can access from `http://localhost:5173/coordinator/#/`. Hopefully if the automation is working, then when this gets released, it'll trigger a deploy to https://caravan-bitcoin.github.io/coordinator/#/

I also changed a bunch of other old urls referencing the old repo and the old unchained website. 