### PR TITLE
fix: deploy action, publish tags on release, and revert coordinator base

### DIFF
--- a/.changeset/grumpy-flies-chew.md
+++ b/.changeset/grumpy-flies-chew.md
@@ -1,0 +1,5 @@
+---
+"@caravan/coordinator": patch
+---
+
+Fix deploy and revert back to original base url for github pages compatibility

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ jobs:
     strategy:
       matrix:
         node-version: ["20.x"]
+    # To use Turborepo Remote Caching
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,9 @@ name: Deploy
 on:
   push:
     tags:
-      - '@caravan/coordinator@*'
+      - '@caravan/coordinator**'
+    branches:
+      - main
 
 permissions:
   contents: write
@@ -12,12 +14,33 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    # To use Turborepo Remote Caching
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
       - name: Install dependencies
         run: npm install
 
-      - name: Deploy
-        run: npx turbo run deploy
+      # the deploy action can't find the build directory if it's in the
+      # sub directory of the monorepo, even if we reference it correctly
+      # so we have to copy it to the root of the repo.
+      - name: Build
+        run: |
+          npx turbo run build
+          cp -R apps/coordinator ./build
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # To use Turborepo Remote Caching
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -45,3 +50,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # For caravan coordinator, there's no publish to npm so no
+      # tag is created. This makes sure we push tags for everything
+      - name: Publish tags
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          npm run publish-tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/apps/coordinator/README.md
+++ b/apps/coordinator/README.md
@@ -10,7 +10,7 @@ addresses.
 Caravan is also stateless. It does not itself store any data. You must
 safekeep the addresses (and redeem scripts & BIP32 paths) you create.
 
-[Try Caravan now!](https://caravan-bitcoin.github.io/coordinator)
+[Try Caravan now!](https://caravan-bitcoin.github.io/caravan)
 
 ## Installation
 
@@ -20,7 +20,7 @@ be run in any web browser from a local or remote installation.
 ### Unchained Capital GitHub
 
 The simplest way to use Caravan is to visit
-[https://caravan-bitcoin.github.io/coordinator](https://caravan-bitcoin.github.io/coordinator),
+[https://caravan-bitcoin.github.io/caravan](https://caravan-bitcoin.github.io/caravan),
 a copy of Caravan hosted on GitHub by
 [Unchained Capital](https://www.unchained.com).
 
@@ -43,7 +43,7 @@ $ turbo run deploy
 ```
 
 You should see a copy of the Caravan web application at
-`https://YOUR_GITHUB_USERNAME.github.io/coordinator`. If not, go back to the
+`https://YOUR_GITHUB_USERNAME.github.io/caravan`. If not, go back to the
 GitHub Pages section and ensure you see a message
 saying "Your site is published at ...".
 
@@ -62,7 +62,7 @@ $ npm run dev
 ...
 ```
 
-Now visit http://localhost:5173/coordinator/# to interact with your local copy of
+Now visit http://localhost:5173/caravan/# to interact with your local copy of
 Caravan.
 
 ### Host Remotely
@@ -105,7 +105,7 @@ Caravan should then be accessible at http://localhost:8000/caravan/#
 ## Usage
 
 If you can access the [Caravan Coordinator web
-application](https://caravan-bitcoin.github.io/coordinator) in your
+application](https://caravan-bitcoin.github.io/caravan) in your
 browser, you are ready to start using Caravan.
 
 Click the _Create_ or _Interact_ links in the navbar to get started.

--- a/apps/coordinator/vite.config.ts
+++ b/apps/coordinator/vite.config.ts
@@ -5,7 +5,7 @@ import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: "/coordinator/#",
+  base: "/caravan/#",
   resolve: {
     alias: {
       utils: path.resolve(__dirname, "./src/utils"),
@@ -19,6 +19,14 @@ export default defineConfig({
   ],
   build: {
     outDir: "build",
+    rollupOptions: {
+      onwarn(warning, warn) {
+        if (warning.code === "MODULE_LEVEL_DIRECTIVE") {
+          return;
+        }
+        warn(warning);
+      },
+    },
   },
   define: {
     __GIT_SHA__: JSON.stringify(process.env.__GIT_SHA__),

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "gen": "turbo gen run",
     "lint": "turbo lint",
     "version": "turbo run build lint test && changeset version",
-    "release": "turbo run build lint test && changeset publish"
+    "release": "turbo run build lint test && changeset publish",
+    "publish-tags": "changeset tag && git push --follow-tags"
   },
   "devDependencies": {
     "@caravan/eslint-config": "*",


### PR DESCRIPTION
Deploy wasn't working as previously written. I was able to get the action to work if I copied the coordinator app's build directory to the root. Added a few other bits of polish including remote cacheing, only deploy on pushed tags to main, and made sure the release workflow pushed tags even for non-npm-published packages.