### PR TITLE
fix: conditional base url subpath for flexible deployments

### DIFF
--- a/.changeset/calm-ligers-chew.md
+++ b/.changeset/calm-ligers-chew.md
@@ -1,0 +1,5 @@
+---
+"@caravan/coordinator": patch
+---
+
+Enable caravan coordinator to be run without the subpath which is primarily just for supporting github pages hosting but causes issues in other environments

--- a/apps/coordinator/Dockerfile
+++ b/apps/coordinator/Dockerfile
@@ -32,8 +32,8 @@ ENV NODE_OPTIONS=--max-old-space-size=32768
 
 RUN npx turbo run build --filter=coordinator...
 
-# Serve the production build files via nginx (will be served at http://localhost:80/caravan/#
+# Serve the production build files via nginx (will be served at http://localhost:80/#
 # in docker vm. Map port 80 to a different port on the host machine to access the app)
 FROM nginx:1.23 AS runner
 WORKDIR /app
-COPY --from=installer /app/apps/coordinator/build /usr/share/nginx/html/caravan
+COPY --from=installer /app/apps/coordinator/build /usr/share/nginx/html/

--- a/apps/coordinator/README.md
+++ b/apps/coordinator/README.md
@@ -62,7 +62,7 @@ $ npm run dev
 ...
 ```
 
-Now visit http://localhost:5173/caravan/# to interact with your local copy of
+Now visit http://localhost:5173/# to interact with your local copy of
 Caravan.
 
 ### Host Remotely
@@ -97,10 +97,10 @@ docker build  -t caravan:latest -f apps/coordinator/Dockerfile .
 To run the built docker image:
 
 ```bash
-docker run -p 80:8000 caravan:latest
+docker run -p 8000:80 caravan:latest
 ```
 
-Caravan should then be accessible at http://localhost:8000/caravan/#
+Caravan should then be accessible at http://localhost:8000/#
 
 ## Usage
 

--- a/apps/coordinator/vite.config.ts
+++ b/apps/coordinator/vite.config.ts
@@ -5,7 +5,11 @@ import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: "/caravan/#",
+  // only need to set the base to a subdirectory when deploying to GitHub Pages
+  // otherwise, if running locally or deploying via alternative like vercel or replit,
+  // then the sub-path can cause issues
+  base:
+    process.env.GH_PAGES || process.env.GITHUB_ACTIONS ? "/caravan/#" : "/#",
   resolve: {
     alias: {
       utils: path.resolve(__dirname, "./src/utils"),


### PR DESCRIPTION
When trying to deploy caravan coordinator in environments other than github pages, the subpath causes some challenges. By making this conditional, caravan can be deployed without custom configuration in somewhere like vercel while still supporting github pages deployements. 

Now normal builds will simply be accessible from http://localhost:5173/# (no /caravan necessary). Same change for the docker deployment.