### PR TITLE
Coordinator descriptors

### DIFF
--- a/.changeset/light-goats-tan.md
+++ b/.changeset/light-goats-tan.md
@@ -1,0 +1,6 @@
+---
+"@caravan/coordinator": minor
+"@caravan/descriptors": patch
+---
+
+Implements a UI for using @caravan/descriptors in the coordinator for importing and exporting descriptors. Includes some cleanup to some build processes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Test
 on: [push, pull_request]
 
 jobs:
-  build:
+  ci:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -1,12 +1,23 @@
 name: Deploy Vercel
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    branches:
+      - main
+    paths-ignore:
+      - '**'
 
 jobs:
   vercel:
     name: Deploy Vercel
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
 
     steps:
       - name: Checkout Repo

--- a/apps/coordinator/package.json
+++ b/apps/coordinator/package.json
@@ -62,7 +62,8 @@
     "standard-version": "^9.0.0",
     "typescript": "^5.0.2",
     "vite": "^4.2.3",
-    "vite-plugin-node-polyfills": "^0.7.0"
+    "vite-plugin-node-polyfills": "^0.7.0",
+    "vite-plugin-wasm": "^3.3.0"
   },
   "scripts": {
     "build": "npm run check && tsc && __GIT_SHA__=`git rev-parse --short HEAD` vite build",
@@ -94,6 +95,7 @@
   "dependencies": {
     "@caravan/bitcoin": "*",
     "@caravan/clients": "*",
+    "@caravan/descriptors": "^0.0.1",
     "@caravan/wallets": "*",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",

--- a/apps/coordinator/src/components/TestSuiteRun/KeystorePicker.tsx
+++ b/apps/coordinator/src/components/TestSuiteRun/KeystorePicker.tsx
@@ -10,6 +10,7 @@ import {
   ACTIVE,
   INDIRECT_KEYSTORES,
   GetMetadata,
+  KEYSTORE_TYPES,
 } from "@caravan/wallets";
 
 import {
@@ -33,7 +34,7 @@ interface KeystorePickerBaseProps {
   setKeystore: (type: string, version: string) => void;
   setKeystoreStatus: (status: string) => void;
   status: string;
-  type: string;
+  type: KEYSTORE_TYPES | "";
   version: string;
 }
 
@@ -61,7 +62,7 @@ const KeystorePickerBase = ({
   };
 
   const interaction = () => {
-    return GetMetadata({ keystore: type });
+    return GetMetadata({ keystore: type as KEYSTORE_TYPES });
   };
 
   const handleTypeChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/coordinator/src/components/Wallet/DownloadDescriptors.tsx
+++ b/apps/coordinator/src/components/Wallet/DownloadDescriptors.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from "react";
+
+import { useSelector } from "react-redux";
+import { Button } from "@mui/material";
+import { getMaskedDerivation } from "@caravan/bitcoin";
+import { encodeDescriptors } from "@caravan/descriptors";
+import { getWalletConfig } from "../../selectors/wallet";
+import { downloadFile } from "../../utils";
+import { KeyOrigin } from "@caravan/wallets";
+
+export const DownloadDescriptors = () => {
+  const walletConfig = useSelector(getWalletConfig);
+  const [descriptors, setDescriptors] = useState({ change: "", receive: "" });
+
+  useEffect(() => {
+    const loadAsync = async () => {
+      const multisigConfig = {
+        requiredSigners: walletConfig.quorum.requiredSigners,
+        keyOrigins: walletConfig.extendedPublicKeys.map(
+          ({ xfp, bip32Path, xpub }: KeyOrigin) => ({
+            xfp,
+            bip32Path: getMaskedDerivation({ xpub, bip32Path }),
+            xpub,
+          }),
+        ),
+        addressType: walletConfig.addressType,
+        network: walletConfig.network,
+      };
+      const { change, receive } = await encodeDescriptors(multisigConfig);
+      setDescriptors({ change, receive });
+    };
+    loadAsync();
+  }, []);
+
+  const handleDownload = () => {
+    if (descriptors.change) {
+      downloadFile(
+        JSON.stringify(descriptors, null, 2),
+        `${walletConfig.uuid}.txt`,
+      );
+    }
+  };
+
+  return (
+    <Button
+      variant="outlined"
+      onClick={handleDownload}
+      disabled={!descriptors.change || !descriptors.receive}
+    >
+      Download Descriptors
+    </Button>
+  );
+};

--- a/apps/coordinator/src/components/Wallet/ExtendedPublicKeyImporters.tsx
+++ b/apps/coordinator/src/components/Wallet/ExtendedPublicKeyImporters.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+import { Box, Grid, Switch, Typography } from "@mui/material";
+import ExtendedPublicKeyImporter from "./ExtendedPublicKeyImporter";
+import { WalletDescriptorImporter } from "./WalletDescriptorImporter";
+
+export const ExtendedPublicKeyImporters = ({
+  totalSigners,
+  configuring,
+}: {
+  totalSigners: number;
+  configuring: boolean;
+}) => {
+  const [withDescriptors, setWithDescriptors] = useState(false);
+
+  const extendedPublicKeyImporters = [];
+  for (
+    let extendedPublicKeyImporterNum = 1;
+    extendedPublicKeyImporterNum <= totalSigners;
+    extendedPublicKeyImporterNum += 1
+  ) {
+    extendedPublicKeyImporters.push(
+      <Box
+        key={extendedPublicKeyImporterNum}
+        mt={extendedPublicKeyImporterNum === 1 ? 0 : 2}
+        display={configuring ? "block" : "none"}
+      >
+        <ExtendedPublicKeyImporter
+          key={extendedPublicKeyImporterNum}
+          number={extendedPublicKeyImporterNum}
+        />
+      </Box>,
+    );
+  }
+
+  if (configuring) {
+    return (
+      <>
+        <Box pb={3} sx={{ display: "flex", justifyContent: "center" }}>
+          <Typography variant="h5">
+            <Switch
+              aria-label="Set Descriptors"
+              onChange={() => setWithDescriptors(!withDescriptors)}
+              checked={withDescriptors}
+            />
+            Configure with descriptor
+          </Typography>
+        </Box>
+        {withDescriptors ? (
+          <Grid item>
+            <WalletDescriptorImporter />
+          </Grid>
+        ) : (
+          extendedPublicKeyImporters
+        )}
+      </>
+    );
+  }
+
+  return <>{extendedPublicKeyImporters}</>;
+};

--- a/apps/coordinator/src/components/Wallet/WalletConfigInteractionButtons.jsx
+++ b/apps/coordinator/src/components/Wallet/WalletConfigInteractionButtons.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Button, Grid } from "@mui/material";
 import { CARAVAN_CONFIG } from "./constants";
+import { DownloadDescriptors } from "./DownloadDescriptors";
 
 const WalletConfigInteractionButtons = ({ onClearFn, onDownloadFn }) => {
   const handleClearClick = (e) => {
@@ -25,6 +26,9 @@ const WalletConfigInteractionButtons = ({ onClearFn, onDownloadFn }) => {
         >
           Clear Wallet
         </Button>
+      </Grid>
+      <Grid item>
+        <DownloadDescriptors />
       </Grid>
     </Grid>
   );

--- a/apps/coordinator/src/components/Wallet/WalletDescriptorImporter.tsx
+++ b/apps/coordinator/src/components/Wallet/WalletDescriptorImporter.tsx
@@ -1,0 +1,110 @@
+import React, { Dispatch, useEffect, useState } from "react";
+import { Button, TextField, Box } from "@mui/material";
+import { useDispatch, useSelector } from "react-redux";
+
+import type { MultisigWalletConfig } from "@caravan/descriptors";
+import { getWalletFromDescriptor, getChecksum } from "@caravan/descriptors";
+import { KeyOrigin } from "@caravan/wallets";
+import {
+  setRequiredSigners,
+  setTotalSigners,
+} from "../../actions/transactionActions";
+import { setAddressType } from "../../actions/settingsActions";
+import {
+  setExtendedPublicKeyImporterBIP32Path,
+  setExtendedPublicKeyImporterExtendedPublicKey,
+  setExtendedPublicKeyImporterExtendedPublicKeyRootFingerprint,
+  setExtendedPublicKeyImporterFinalized,
+  setExtendedPublicKeyImporterMethod,
+  setExtendedPublicKeyImporterName,
+} from "../../actions/extendedPublicKeyImporterActions";
+import { updateWalletUuidAction } from "../../actions/walletActions";
+import { BitcoinNetwork, MultisigAddressType } from "@caravan/bitcoin";
+
+const importWalletDetails = (
+  {
+    keyOrigins,
+    requiredSigners,
+    addressType,
+  }: {
+    keyOrigins: KeyOrigin[];
+    requiredSigners: number;
+    addressType: MultisigAddressType;
+  },
+  dispatch: Dispatch<any>,
+) => {
+  dispatch(setTotalSigners(keyOrigins.length));
+  dispatch(setRequiredSigners(requiredSigners));
+  dispatch(setAddressType(addressType));
+  keyOrigins.forEach(({ xfp, bip32Path, xpub }, index) => {
+    const number = index + 1;
+    dispatch(setExtendedPublicKeyImporterName(number, `key_${number}_${xfp}`));
+    dispatch(setExtendedPublicKeyImporterMethod(number, "text"));
+    dispatch(setExtendedPublicKeyImporterBIP32Path(number, bip32Path));
+    dispatch(
+      setExtendedPublicKeyImporterExtendedPublicKeyRootFingerprint(number, xfp),
+    );
+    dispatch(setExtendedPublicKeyImporterExtendedPublicKey(number, xpub));
+    dispatch(setExtendedPublicKeyImporterFinalized(number, true));
+  });
+};
+
+export const WalletDescriptorImporter = () => {
+  const [walletConfig, setWalletConfig] = useState<MultisigWalletConfig>();
+  const [descriptor, setDescriptor] = useState<string>("");
+  const [descriptorError, setDescriptorError] = useState<string>("");
+
+  const network = useSelector(
+    (state: { quorum: { network: BitcoinNetwork } }) => state.quorum.network,
+  );
+  const dispatch = useDispatch();
+  useEffect(() => {
+    if (walletConfig) {
+      importWalletDetails(walletConfig, dispatch);
+    }
+  }, [walletConfig]);
+
+  const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
+
+    const { value } = e.target;
+
+    if (!value) {
+      setDescriptorError("");
+    } else {
+      setDescriptor(value);
+    }
+  };
+
+  const handleClick = async () => {
+    try {
+      const config = await getWalletFromDescriptor(descriptor, network);
+      const checksum = await getChecksum(descriptor);
+      console.log(config);
+      dispatch(updateWalletUuidAction(checksum));
+      setWalletConfig(config);
+    } catch (e) {
+      console.error(e.message);
+      setDescriptorError(e.message);
+    }
+  };
+
+  const helperText = `Please enter one of the wallet's descriptors (change or receive).
+Make sure any settings that are not in a descriptor are set before submitting.`;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <TextField
+        multiline
+        label="Descriptor"
+        placeholder="sh(...)"
+        onChange={handleChange}
+        helperText={descriptorError || helperText}
+        error={!!descriptorError}
+      />
+      <Button color="secondary" variant="contained" onClick={handleClick}>
+        Import Descriptor
+      </Button>
+    </Box>
+  );
+};

--- a/apps/coordinator/src/components/Wallet/index.jsx
+++ b/apps/coordinator/src/components/Wallet/index.jsx
@@ -27,7 +27,6 @@ import AddressTypePicker from "../AddressTypePicker";
 import ClientPicker from "../ClientPicker";
 import StartingAddressIndexPicker from "../StartingAddressIndexPicker";
 import WalletGenerator from "./WalletGenerator";
-import ExtendedPublicKeyImporter from "./ExtendedPublicKeyImporter";
 import WalletActionsPanel from "./WalletActionsPanel";
 import {
   getUnknownAddresses,
@@ -58,7 +57,6 @@ import {
   SET_CLIENT_USERNAME,
 } from "../../actions/clientActions";
 import { clientPropTypes, slicePropTypes } from "../../proptypes";
-import { WalletDescriptorImporter } from "./WalletDescriptorImporter";
 import { ExtendedPublicKeyImporters } from "./ExtendedPublicKeyImporters";
 
 class CreateWallet extends React.Component {

--- a/apps/coordinator/src/components/Wallet/index.jsx
+++ b/apps/coordinator/src/components/Wallet/index.jsx
@@ -58,6 +58,8 @@ import {
   SET_CLIENT_USERNAME,
 } from "../../actions/clientActions";
 import { clientPropTypes, slicePropTypes } from "../../proptypes";
+import { WalletDescriptorImporter } from "./WalletDescriptorImporter";
+import { ExtendedPublicKeyImporters } from "./ExtendedPublicKeyImporters";
 
 class CreateWallet extends React.Component {
   static validateProperties(config, properties, key) {
@@ -393,30 +395,6 @@ class CreateWallet extends React.Component {
     return settings;
   };
 
-  renderExtendedPublicKeyImporters = () => {
-    const { totalSigners, configuring } = this.props;
-    const extendedPublicKeyImporters = [];
-    for (
-      let extendedPublicKeyImporterNum = 1;
-      extendedPublicKeyImporterNum <= totalSigners;
-      extendedPublicKeyImporterNum += 1
-    ) {
-      extendedPublicKeyImporters.push(
-        <Box
-          key={extendedPublicKeyImporterNum}
-          mt={extendedPublicKeyImporterNum === 1 ? 0 : 2}
-          display={configuring ? "block" : "none"}
-        >
-          <ExtendedPublicKeyImporter
-            key={extendedPublicKeyImporterNum}
-            number={extendedPublicKeyImporterNum}
-          />
-        </Box>,
-      );
-    }
-    return extendedPublicKeyImporters;
-  };
-
   downloadWalletDetails = (event) => {
     const { walletDetailsText } = this.props;
     event.preventDefault();
@@ -542,7 +520,10 @@ class CreateWallet extends React.Component {
               </Grid>
             </Grid>
             <Grid item md={configuring ? 8 : 12}>
-              {this.renderExtendedPublicKeyImporters()}
+              <ExtendedPublicKeyImporters
+                totalSigners={this.props.totalSigners}
+                configuring={this.props.configuring}
+              />
               <Box mt={2}>
                 <WalletGenerator
                   generating={generating}

--- a/apps/coordinator/types/unchained-wallets/index.d.ts
+++ b/apps/coordinator/types/unchained-wallets/index.d.ts
@@ -1,1 +1,0 @@
-declare module "@caravan/wallets";

--- a/apps/coordinator/vite.config.ts
+++ b/apps/coordinator/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import path from "path";
+import wasm from "vite-plugin-wasm";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -10,12 +11,14 @@ export default defineConfig({
   // then the sub-path can cause issues
   base:
     process.env.GH_PAGES || process.env.GITHUB_ACTIONS ? "/caravan/#" : "/#",
+  assetsInclude: ["**/*.wasm"],
   resolve: {
     alias: {
       utils: path.resolve(__dirname, "./src/utils"),
     },
   },
   plugins: [
+    wasm(),
     react(),
     nodePolyfills({
       protocolImports: true,
@@ -35,5 +38,9 @@ export default defineConfig({
   define: {
     __GIT_SHA__: JSON.stringify(process.env.__GIT_SHA__),
     __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+  },
+  optimizeDeps: {
+    // needed for local development to support proper handling of wasm
+    // exclude: ["@caravan/descriptors"],
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "dependencies": {
         "@caravan/bitcoin": "*",
         "@caravan/clients": "*",
+        "@caravan/descriptors": "^0.0.1",
         "@caravan/wallets": "*",
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
@@ -113,7 +114,8 @@
         "standard-version": "^9.0.0",
         "typescript": "^5.0.2",
         "vite": "^4.2.3",
-        "vite-plugin-node-polyfills": "^0.7.0"
+        "vite-plugin-node-polyfills": "^0.7.0",
+        "vite-plugin-wasm": "^3.3.0"
       },
       "engines": {
         "node": ">=20"
@@ -23809,6 +23811,15 @@
         "vite": "^2.0.0 || ^3.0.0 || ^4.0.0"
       }
     },
+    "node_modules/vite-plugin-wasm": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.3.0.tgz",
+      "integrity": "sha512-tVhz6w+W9MVsOCHzxo6SSMSswCeIw4HTrXEi6qL3IRzATl83jl09JVO1djBqPSwfjgnpVHNLYcaMbaDX5WB/pg==",
+      "dev": true,
+      "peerDependencies": {
+        "vite": "^2 || ^3 || ^4 || ^5"
+      }
+    },
     "node_modules/vite/node_modules/rollup": {
       "version": "3.29.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
@@ -24345,7 +24356,7 @@
     },
     "packages/caravan-bitcoin": {
       "name": "@caravan/bitcoin",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@babel/polyfill": "^7.7.0",
@@ -26210,9 +26221,10 @@
     },
     "packages/caravan-descriptors": {
       "name": "@caravan/descriptors",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "dependencies": {
-        "@caravan/bitcoin": "*"
+        "@caravan/bitcoin": "*",
+        "@caravan/wallets": "*"
       },
       "devDependencies": {
         "shx": "^0.3.4"

--- a/packages/caravan-clients/src/client.test.ts
+++ b/packages/caravan-clients/src/client.test.ts
@@ -68,7 +68,7 @@ describe("ClientBase", () => {
     const endTime = Date.now();
 
     const elapsedTime = endTime - startTime;
-    expect(elapsedTime).toBeGreaterThanOrEqual(500); // Assuming delay() is 1000ms
+    expect(elapsedTime).toBeGreaterThan(499); // Assuming delay() is 500
   });
 });
 

--- a/packages/caravan-descriptors/README.md
+++ b/packages/caravan-descriptors/README.md
@@ -32,7 +32,6 @@ $ npm run test
 ```
 This will run the TypeScript tests only.
 
-
 ### Web
 You'll need to make sure that the web environment this is used in
 supports wasm. For example, if you're using in a vite.js project
@@ -41,6 +40,18 @@ you'll need the `vite-plugin-wasm` plugin.
 Also note that all functions exported are async and need to be awaited
 since they will load up the wasm modules to be used (this way consumers
 of the library don't have to worry about loading up the modules themselves)
+
+## Development
+### Usage in Monorepo
+While this package is used on `@caravan/coordinator`, due to the "special" requirements needed
+to build this package for usage in `@caravan/coordinator`, the local version of `@caravan/descriptors` is not explicitly
+linked in the package.json but instead the published version is referenced. This means
+that users who aren't setup to build the wasm dependencies can still build the coordinator.
+
+If you want to work on an update to this package and test them out in a web environment,
+simply change the `@caravan/coordinator` package.json to be `"@caravan/descriptors": "*"`
+and run `npm install && turbo run dev` from the root. Make sure to revert the dependency though
+before finalizing your Pull Request.
 
 
 ## API
@@ -56,3 +67,4 @@ the two corresponding descriptors
 Take two descriptors and convert them into a multisig wallet
 config object. This will make it possible to determine and parse the wallet type
 (e.g. P2SH) and the key origins.
+

--- a/packages/caravan-descriptors/package.json
+++ b/packages/caravan-descriptors/package.json
@@ -27,7 +27,8 @@
     "test:debug": "node --inspect-brk ../../node_modules/.bin/jest --runInBand"
   },
   "dependencies": {
-    "@caravan/bitcoin": "*"
+    "@caravan/bitcoin": "*",
+    "@caravan/wallets": "*"
   },
   "devDependencies": {
     "shx": "^0.3.4"

--- a/packages/caravan-descriptors/package.json
+++ b/packages/caravan-descriptors/package.json
@@ -21,7 +21,7 @@
     "copy-wasm": "shx mkdir -p dist/caravan-rs/pkg-web && shx mkdir -p dist/caravan-rs/pkg-nodejs && shx cp -R caravan-rs/pkg-web/* dist/caravan-rs/pkg-web/ && shx cp -R caravan-rs/pkg-nodejs/* dist/caravan-rs/pkg-nodejs/",
     "dev": "npm run build -- --watch",
     "lint": "eslint src",
-    "ci": "npm run build && npm run lint && npm run test",
+    "ci": "npm run lint && npm run test",
     "test": "npm run build && jest src",
     "test:watch": "jest --watch src",
     "test:debug": "node --inspect-brk ../../node_modules/.bin/jest --runInBand"

--- a/packages/caravan-descriptors/src/descriptors.test.ts
+++ b/packages/caravan-descriptors/src/descriptors.test.ts
@@ -1,12 +1,12 @@
 import { Network } from '@caravan/bitcoin';
 import {
-  KeyOrigin,
   MultisigWalletConfig,
   decodeDescriptors,
   encodeDescriptors,
   getChecksum,
   getWalletFromDescriptor,
 } from "./descriptors";
+import { KeyOrigin } from "@caravan/wallets";
 
 const external =
   "sh(sortedmulti(2,[f57ec65d/45'/0'/100']xpub6CCHViYn5VzPfSR7baop9FtGcbm3UnqHwa54Z2eNvJnRFCJCdo9HtCYoLJKZCoATMLUowDDA1BMGfQGauY3fDYU3HyMzX4NDkoLYCSkLpbH/0/*,[efa5d916/45'/0'/100']xpub6Ca5CwTgRASgkXbXE5TeddTP9mPCbYHreCpmGt9dhz9y6femstHGCoFESHHKKRcm414xMKnuLjP9LDS7TwaJC9n5gxua6XB1rwPcC6hqDub/0/*))#uxj9xxul";

--- a/packages/caravan-descriptors/src/descriptors.ts
+++ b/packages/caravan-descriptors/src/descriptors.ts
@@ -1,38 +1,36 @@
 import { getRustAPI } from "./wasmLoader";
 import {
-  BitcoinNetwork,
   MultisigAddressType,
+  Network,
   validateExtendedPublicKeyForNetwork,
 } from "@caravan/bitcoin";
-
-// TODO: should come from unchained-wallets
-export interface KeyOrigin {
-  xfp: string;
-  bip32Path: string;
-  xpub: string;
-}
+import { KeyOrigin } from "@caravan/wallets";
 
 // should be a 32 byte hex string
 export type PolicyHmac = string;
 // should be an 8 byte hex string
 export type RootFingerprint = string;
 
+// This interface is different from the one that is
+// exported from the `@caravan/wallets` package, which
+// is primarily built for the original caravan config
+// and has some unnecessary config fields (e.g. quorum).
 export interface MultisigWalletConfig {
   requiredSigners: number;
   addressType: MultisigAddressType;
   keyOrigins: KeyOrigin[];
-  network: BitcoinNetwork | "bitcoin";
+  network: Network | "bitcoin";
 }
 
 export const decodeDescriptors = async (
   internal: string,
   external: string,
-  network?: BitcoinNetwork,
+  network?: Network | "bitcoin",
 ): Promise<MultisigWalletConfig> => {
   const { ExtendedDescriptor, CaravanConfig, Network } = await getRustAPI();
   const external_descriptor = ExtendedDescriptor.from_str(external);
   const internal_descriptor = ExtendedDescriptor.from_str(internal);
-  let _network: BitcoinNetwork | "bitcoin";
+  let _network: Network | "bitcoin";
   if (network === "mainnet" || !network) {
     _network = "bitcoin";
   } else {
@@ -109,7 +107,7 @@ export const getChecksum = async (descriptor: string) => {
 
 export const getWalletFromDescriptor = async (
   descriptor: string,
-  network?: BitcoinNetwork,
+  network?: Network,
 ): Promise<MultisigWalletConfig> => {
   let internal: string = "",
     external: string = "";

--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,7 @@
     "lint": {},
     "test": {
       "dependsOn": [
-        "^build"
+        "^build, build"
       ]
     },
     "test:debug": {

--- a/turbo.json
+++ b/turbo.json
@@ -36,7 +36,7 @@
       "dependsOn": ["build"]
     },
     "ci": {
-
+      "dependsOn": ["^build", "build"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -36,7 +36,7 @@
       "dependsOn": ["build"]
     },
     "ci": {
-      "dependsOn": ["^build"]
+
     }
   }
 }


### PR DESCRIPTION
Re-implementation of this original WIP PR from the legacy repo: https://github.com/unchained-capital/caravan/pull/340

There are a couple new UI elements:

1. A switch to choose if you want to import by xpubs/devices or descriptors
<img width="1264" alt="Screenshot 2024-02-25 at 5 54 53 PM" src="https://github.com/caravan-bitcoin/caravan/assets/4344978/5719a752-ebcc-4a54-ac47-626a87c41337">

2. The descriptor importer itself
<img width="1268" alt="Screenshot 2024-02-25 at 5 55 04 PM" src="https://github.com/caravan-bitcoin/caravan/assets/4344978/e5263581-c5bd-4e88-8158-b24c9d8f3560">

3. A button to download the descriptors as a txt file from the wallet overview
<img width="1274" alt="Screenshot 2024-02-25 at 5 55 16 PM" src="https://github.com/caravan-bitcoin/caravan/assets/4344978/6655a93f-b0ae-45d0-91f3-58186afb23ed">

The UX is still a little rough around the edges (for example, you have to select the network and client _FIRST_ before importing the descriptor), but that can be cleaned up later (ideally with a more comprehensive rewrite that does a wizard style wallet setup flow).

Here's a descriptor from one of the test suite fixtures to test with:
```
wsh(sortedmulti(2,[f57ec65d/48'/0'/100'/2']xpub6DcqYQxnbefzFkaRBK63FSE2GzNuNnNhFGw1xV9RioVG7av6r3JDf1aELqBSq5gt5487CtNxvVtaiJjQU2HQWzgG5NzLyTPbYav6otW8qEc/1/*,[00000006/48'/0'/100'/2']xpub6EwJjKaiocGvqSuM2jRZSuQ9HEddiFUFu9RdjE47zG7kXVNDQpJ3GyvskwYiLmvU4SBTNZyv8UH53QcmFEE23YwozE61V3dwzZJEFQr6H2b/1/*))#kmvcnunj
```