### PR TITLE
use vercel environment variable as a fallback for git sha if available

### DIFF
--- a/apps/coordinator/vite.config.ts
+++ b/apps/coordinator/vite.config.ts
@@ -36,7 +36,10 @@ export default defineConfig({
     },
   },
   define: {
-    __GIT_SHA__: JSON.stringify(process.env.__GIT_SHA__),
+    __GIT_SHA__: JSON.stringify(
+      process.env.__GIT_SHA__ ||
+        (process.env.__VERCEL_GIT_COMMIT_SHA__ || "").slice(0, 7),
+    ),
     __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
   },
   optimizeDeps: {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,13 @@
   "engines": {
     "node": ">=20"
   },
+  "overrides": {
+    "jspdf": "2.5.1",
+    "@ledgerhq/hw-transport-webusb": {
+      "@ledgerhq/hw-transport": "6.28.1",
+      "@ledgerhq/devices": "8.0.0"
+    }
+  },
   "packageManager": "npm@10.2.3",
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
Small change to make sure git sha is available in vercel deployments for the coordinator footer