### PR TITLE
feat: add latest tag for main branch builds

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -20,7 +20,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -34,5 +34,7 @@ jobs:
           context: .
           file: ./apps/coordinator/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
1. Changes secret from `DOCKER_PASSWORD` to `DOCKER_TOKEN` because its actually an access token.
2. attempt to add the latest tag to `main` branch builds.