### PR TITLE
fix: public client broadcast call

### DIFF
--- a/.changeset/shaggy-vans-shave.md
+++ b/.changeset/shaggy-vans-shave.md
@@ -1,0 +1,5 @@
+---
+"@caravan/clients": patch
+---
+
+Fixes a bug in the mempool broadcast request

--- a/packages/caravan-clients/src/client.test.ts
+++ b/packages/caravan-clients/src/client.test.ts
@@ -181,7 +181,7 @@ describe("BlockchainClient", () => {
       const result = await blockchainClient.broadcastTransaction(rawTx);
 
       // Verify the mock axios instance was called with the correct URL and data
-      expect(mockPost).toHaveBeenCalledWith(`/tx`, { tx: rawTx });
+      expect(mockPost).toHaveBeenCalledWith(`/tx`, rawTx);
 
       // Verify the returned result
       expect(result).toEqual(mockResponse);

--- a/packages/caravan-clients/src/client.ts
+++ b/packages/caravan-clients/src/client.ts
@@ -160,12 +160,7 @@ export class BlockchainClient extends ClientBase {
           ...this.bitcoindParams,
         });
       }
-      if (this.type === ClientType.BLOCKSTREAM) {
-        return await this.Post(`/tx`, rawTx);
-      }
-      if (this.type === ClientType.MEMPOOL) {
-        return await this.Post(`/tx`, { tx: rawTx });
-      }
+      return await this.Post(`/tx`, rawTx);
     } catch (error: any) {
       throw new Error(`Failed to broadcast transaction: ${error.message}`);
     }


### PR DESCRIPTION
Should resolve an issue where transactions couldn't broadcast with mempool.space.

Unclear how the api request body got twisted like this. Before the latest change to these lines, it was the same for both clients but in the way mempool.space was before this change. So they are now both the same again, but in the way fixed previously for blockstream (I did have a memory of actually fixing this before and I guess that's why). 