### PR TITLE
fix: descope coordinator app

### DIFF
--- a/apps/coordinator/package.json
+++ b/apps/coordinator/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@caravan/coordinator",
+  "name": "caravan-coordinator",
+  "private": true,
   "version": "0.3.0",
   "description": "Unchained Capital's Bitcoin Multisig Coordinator Application",
   "main": "index.jsx",
-  "private": true,
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Caravan coordinator is an app, not an npm package, so the @scope/package naming pattern isn't needed.  This will enable us to quickly identify on the https://github.com/caravan-bitcoin/caravan/releases which release is a package release, and which is an app release.