### PR TITLE
fix: better docker tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - '**/coordinator**'
+      - '**caravan**coordinator@[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
   contents: write

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - '**/coordinator**'
+      - '**caravan**coordinator@[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   docker:
@@ -21,7 +21,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: caravanbitcoin/caravan
+          images: caravanbitcoin/coordinator
+          tags: |
+            type=match,pattern=@(\d.\d.\d),group=1
+            type=match,pattern=@(\d.\d),group=1
+            type=sha
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
- github action should run only on caravan coordinator tags with an `@X.Y.Z` version
- change the image name to `caravanbitcoin/coordinator`, as `caravanbitcoin/caravan` felt redundant.
- Tags are versions, so `@1.0.0` would generate both `1.0.0` and `1.0`.  Also, a @1.0.1 version would generate a new `1.0.1` and update the `1.0`.