### PR TITLE
fix: bump coordinator version

### DIFF
--- a/.changeset/eleven-hairs-talk.md
+++ b/.changeset/eleven-hairs-talk.md
@@ -1,0 +1,5 @@
+---
+"caravan-coordinator": patch
+---
+
+Update coordinator with wallets 0.1.2 and clients 0.0.3


### PR DESCRIPTION
Patch coordinator version so [@caravan/wallets@0.1.2](https://github.com/caravan-bitcoin/caravan/releases/tag/%40caravan%2Fwallets%400.1.2) and [@caravan/clients@0.0.3](https://github.com/caravan-bitcoin/caravan/releases/tag/%40caravan%2Fclients%400.0.3) are included.