### PR TITLE
Update version in package-lock on release

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "gen": "turbo gen run",
     "lint": "turbo lint",
-    "version": "turbo run build && turbo lint test && changeset version",
+    "version": "turbo run build && turbo lint test && changeset version && npm install --package-lock-only",
     "release": "turbo run build && turbo lint test && changeset publish",
     "dev:coordinator": "turbo run dev --filter=caravan-coordinator",
     "publish-tags": "changeset tag && git push --follow-tags"


### PR DESCRIPTION
`changeset version` updates package.json, but not package-lock.json.

Changeset has an open issue for this, https://github.com/changesets/action/issues/203.  

A suggested workaround is to use `npm install`, https://github.com/changesets/action/issues/203#issuecomment-1460115073