### PR TITLE
Add DockerHub icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Vercel Deploy](https://therealsujitk-vercel-badge.vercel.app/?app=caravan-coordinator)](https://caravan-coordinator.vercel.app)
 [![Hosted Coordinator](https://github.com/caravan-bitcoin/caravan/actions/workflows/deploy.yml/badge.svg)](https://caravan-bitcoin.github.io/caravan/#/)
 ![Package Publication](https://github.com/caravan-bitcoin/caravan/actions/workflows/release.yml/badge.svg)
+[![Pulls from DockerHub](https://img.shields.io/docker/pulls/caravanbitcoin/coordinator?logo=docker)](https://hub.docker.com/r/caravanbitcoin/coordinator)
 
 ## Introduction
 


### PR DESCRIPTION
This PR adds a Docker badge to the repo's README.

[![Pulls from DockerHub](https://img.shields.io/docker/pulls/caravanbitcoin/coordinator?logo=docker)](https://hub.docker.com/r/caravanbitcoin/coordinator)

I love that you are publishing a Docker image, however it was nearly impossible to know there was a Docker image at all. I wanted to make sure I was using the Official image created from this open source repo. I looked through all the GitHub actions and found that it was publishing to 
 https://hub.docker.com/r/caravanbitcoin/coordinator so I think it will be great for other user's to also see the Docker repo.