### PR TITLE
Psbtv2 operator role validation

### DIFF
--- a/.changeset/cool-cows-learn.md
+++ b/.changeset/cool-cows-learn.md
@@ -1,0 +1,5 @@
+---
+"@caravan/psbt": minor
+---
+
+PsbtV2 operator role validation getters are added to provide a way for validating role readiness. These getters are used in some Constructor and Signer methods. For example, an error will be thrown if `addPartialSig` is called when the PsbtV2 is not ready for a Signer.

--- a/packages/caravan-psbt/README.md
+++ b/packages/caravan-psbt/README.md
@@ -110,7 +110,7 @@ Getters and setters are provided for the keytypes defined in [BIP 174](https://g
 
 ##### `get isReadyForConstructor`
 
-A getter to check readiness for an operator role. Operator roles are defined in defined in [BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#user-content-Roles) and [BIP 370](https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki#user-content-Roles).
+A getter to check readiness for an operator role. Operator roles are defined in [BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#user-content-Roles) and [BIP 370](https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki#user-content-Roles).
 
 Returns `true` if the PsbtV2 is ready for an operator taking the Constructor role.
 
@@ -118,7 +118,7 @@ This check assumes that the Creator used this class's constructor method to init
 
 ##### `get isReadyForUpdater`
 
-A getter to check readiness for an operator role. Operator roles are defined in defined in [BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#user-content-Roles) and [BIP 370](https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki#user-content-Roles).
+A getter to check readiness for an operator role. Operator roles are defined in [BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#user-content-Roles) and [BIP 370](https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki#user-content-Roles).
 
 Returns `true` if the PsbtV2 is ready for an operator taking the Updater role.
 
@@ -128,7 +128,7 @@ According to BIP370, the Updater can modify the sequence number, but it is uncle
 
 ##### `get isReadyForSigner`
 
-A getter to check readiness for an operator role. Operator roles are defined in defined in [BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#user-content-Roles) and [BIP 370](https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki#user-content-Roles).
+A getter to check readiness for an operator role. Operator roles are defined in [BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#user-content-Roles) and [BIP 370](https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki#user-content-Roles).
 
 Returns `true` if the PsbtV2 is ready for an operator taking the Signer role.
 
@@ -138,7 +138,7 @@ A future improvement to this method might be to more thoroughly check inputs to 
 
 ##### `get isReadyForCombiner`
 
-A getter to check readiness for an operator role. Operator roles are defined in defined in [BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#user-content-Roles) and [BIP 370](https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki#user-content-Roles).
+A getter to check readiness for an operator role. Operator roles are defined in [BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#user-content-Roles) and [BIP 370](https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki#user-content-Roles).
 
 Returns `true` if the PsbtV2 is ready for an operator taking the Combiner role.
 
@@ -146,13 +146,13 @@ Since a Combiner can potentially provide everything needed to a mostly blank Psb
 
 ##### `get isReadyForInputFinalizer`
 
-A getter to check readiness for an operator role. Operator roles are defined in defined in [BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#user-content-Roles) and [BIP 370](https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki#user-content-Roles).
+A getter to check readiness for an operator role. Operator roles are defined in [BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#user-content-Roles) and [BIP 370](https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki#user-content-Roles).
 
 Callable, but unimplemented. Returns `undefined`.
 
 ##### `get isReadyForTransactionExtractor`
 
-A getter to check readiness for an operator role. Operator roles are defined in defined in [BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#user-content-Roles) and [BIP 370](https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki#user-content-Roles).
+A getter to check readiness for an operator role. Operator roles are defined in [BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#user-content-Roles) and [BIP 370](https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki#user-content-Roles).
 
 Callable, but unimplemented. Returns `undefined`.
 

--- a/packages/caravan-psbt/README.md
+++ b/packages/caravan-psbt/README.md
@@ -154,7 +154,9 @@ Callable, but unimplemented. Returns `undefined`.
 
 A getter to check readiness for an operator role. Operator roles are defined in [BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#user-content-Roles) and [BIP 370](https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki#user-content-Roles).
 
-Callable, but unimplemented. Returns `undefined`.
+Returns `true` if the PsbtV2 is ready for an operator taking the Transaction Extractor role.
+
+If all the inputs have been finalized, then the psbt is ready for the Transaction Extractor. According to BIP 174, it's the responsibility of the Input Finalizer to add scriptSigs or scriptWitnesses and then remove other details besides the UTXO. This getter checks that the Input Finalizer has finished its job.
 
 ##### `get nLockTime`
 

--- a/packages/caravan-psbt/src/psbtv2/psbtv2.test.ts
+++ b/packages/caravan-psbt/src/psbtv2/psbtv2.test.ts
@@ -1,5 +1,6 @@
 import { PsbtV2, getPsbtVersionNumber } from "./";
 import { test } from "@jest/globals";
+import { PsbtGlobalTxModifiableBits } from "./types";
 
 const BIP_370_VECTORS_INVALID_PSBT = [
   // Case: PSBTv0 but with PSBT_GLOBAL_VERSION set to 2.
@@ -818,6 +819,89 @@ describe("PsbtV2", () => {
   });
 });
 
+describe("PsbtV2.isReadyForConstructor", () => {
+  let psbt: PsbtV2;
+
+  beforeEach(() => {
+    psbt = new PsbtV2();
+  });
+
+  it("Returns not ready for Constructor when PSBT_GLOBAL_FALLBACK_LOCKTIME is not set", () => {
+    psbt.PSBT_GLOBAL_FALLBACK_LOCKTIME = null;
+    expect(psbt.isReadyForConstructor).toBe(false);
+  });
+
+  it("Returns not ready for Constructor when neither inputs or outputs are modifiable", () => {
+    psbt.PSBT_GLOBAL_TX_MODIFIABLE = [];
+    expect(psbt.isReadyForConstructor).toBe(false);
+  });
+
+  it("Returns ready for Constructor when created with the object class constructor method", () => {
+    expect(psbt.isReadyForConstructor).toBe(true);
+  });
+
+  it("Returns ready for Constructor when a custom PSBT_GLOBAL_FALLBACK_LOCKTIME has been set", () => {
+    psbt.PSBT_GLOBAL_FALLBACK_LOCKTIME = 500000000;
+    expect(psbt.isReadyForConstructor).toBe(true);
+  });
+
+  it("Returns ready for Constructor when at least inputs or outputs are modifiable", () => {
+    psbt.PSBT_GLOBAL_TX_MODIFIABLE = [PsbtGlobalTxModifiableBits.INPUTS];
+    expect(psbt.isReadyForConstructor).toBe(true);
+    psbt.PSBT_GLOBAL_TX_MODIFIABLE = [PsbtGlobalTxModifiableBits.OUTPUTS];
+    expect(psbt.isReadyForConstructor).toBe(true);
+  });
+});
+
+describe("PsbtV2.isReadyForUpdater", () => {
+  let psbt: PsbtV2;
+
+  beforeEach(() => {
+    psbt = new PsbtV2();
+    psbt.addInput({ previousTxId: Buffer.from([0x00]), outputIndex: 0 });
+    psbt.PSBT_GLOBAL_TX_MODIFIABLE = [PsbtGlobalTxModifiableBits.INPUTS];
+  });
+
+  it("Returns not ready for Updater when there are no inputs to update", () => {
+    psbt.deleteInput(0);
+    expect(psbt.isReadyForUpdater).toBe(false);
+  });
+
+  it("Returns not ready for Updater when there are no modifiable inputs", () => {
+    psbt.PSBT_GLOBAL_TX_MODIFIABLE = [];
+    expect(psbt.isReadyForUpdater).toBe(false);
+  });
+
+  it("Returns ready for Updater when it has at least one input and inputs are modifiable", () => {
+    expect(psbt.isReadyForUpdater).toBe(true);
+  });
+});
+
+describe("PsbtV2.isReadyForSigner", () => {
+  let psbt: PsbtV2;
+
+  beforeEach(() => {
+    psbt = new PsbtV2();
+    psbt.addInput({ previousTxId: Buffer.from([0x00]), outputIndex: 0 });
+  });
+
+  it("Returns not ready for Signer when there are no inputs to sign", () => {
+    psbt.deleteInput(0);
+    expect(psbt.isReadyForSigner).toBe(false);
+  });
+
+  it("Returns not ready for Signer when the psbt has already finalized inputs", () => {
+    jest
+      .spyOn(psbt, "isReadyForTransactionExtractor", "get")
+      .mockReturnValue(true);
+    expect(psbt.isReadyForSigner).toBe(false);
+  });
+
+  it("Returns ready for Signer when the psbt has an input for signing", () => {
+    expect(psbt.isReadyForSigner).toBe(true);
+  });
+});
+
 describe("PsbtV2.nLockTime", () => {
   it("Returns 0 when No locktimes specified", () => {
     const vect = BIP_370_VECTORS_VALID_PSBT[14];
@@ -1024,9 +1108,14 @@ describe("PsbtV2.addPartialSig", () => {
   it("Throws on validation failures", () => {
     const addSig = (index: number, pub?: any, sig?: any) =>
       psbt.addPartialSig(index, pub, sig);
-    expect(() => addSig(0)).toThrow("PsbtV2 has no input at 0");
+
+    // No inputs, so it's not ready for Signer
+    expect(() => addSig(0)).toThrow(
+      "The PsbtV2 is not ready for a Signer. Partial sigs cannot be added.",
+    );
 
     psbt.addInput({ previousTxId: Buffer.from([0x00]), outputIndex: 0 });
+    expect(() => addSig(1)).toThrow("PsbtV2 has no input at 1");
     expect(() => addSig(0)).toThrow(
       "PsbtV2.addPartialSig() missing argument pubkey",
     );

--- a/packages/caravan-psbt/src/psbtv2/psbtv2.ts
+++ b/packages/caravan-psbt/src/psbtv2/psbtv2.ts
@@ -588,6 +588,7 @@ export class PsbtV2 extends PsbtV2Maps {
    */
   get isReadyForTransactionExtractor(): boolean {
     // Iterate over all inputs
+
     for (let i = 0; i < this.PSBT_GLOBAL_INPUT_COUNT; i++) {
       // Check for finalized script
       if (
@@ -607,17 +608,27 @@ export class PsbtV2 extends PsbtV2Maps {
       }
 
       // Check that Input Finalizer removed other values from the input.
+      //
+      // Test vectors from BIP 370 indicate that a missing PSBT_IN_OUTPUT_INDEX
+      // or PSBT_IN_PREVIOUS_TXID should be an invalid psbt, so the getters for
+      // these keys will throw unless the values are set. However, the BIP also
+      // requires that the Input Finalizer removes all other values from the
+      // input map except for the finalized scripts and UTXOs. Since removal of
+      // the above mentioned keys will result in an invalid psbt, it's decided
+      // here that it's safe to ignore the fact that those keys have not been
+      // removed.
       if (
-        // Unique key types: Check the value
         this.PSBT_IN_SIGHASH_TYPE[i] ||
+        this.PSBT_IN_SIGHASH_TYPE[i] === 0 ||
         this.PSBT_IN_REDEEM_SCRIPT[i] ||
         this.PSBT_IN_WITNESS_SCRIPT[i] ||
         this.PSBT_IN_POR_COMMITMENT[i] ||
-        this.PSBT_IN_PREVIOUS_TXID[i] ||
-        this.PSBT_IN_OUTPUT_INDEX[i] ||
         this.PSBT_IN_SEQUENCE[i] ||
+        this.PSBT_IN_SEQUENCE[i] === 0 ||
         this.PSBT_IN_REQUIRED_TIME_LOCKTIME[i] ||
+        this.PSBT_IN_REQUIRED_TIME_LOCKTIME[i] === 0 ||
         this.PSBT_IN_REQUIRED_HEIGHT_LOCKTIME[i] ||
+        this.PSBT_IN_REQUIRED_HEIGHT_LOCKTIME[i] === 0 ||
         this.PSBT_IN_TAP_KEY_SIG[i] ||
         this.PSBT_IN_TAP_INTERNAL_KEY[i] ||
         this.PSBT_IN_TAP_MERKLE_ROOT[i] ||

--- a/packages/caravan-psbt/src/psbtv2/psbtv2.ts
+++ b/packages/caravan-psbt/src/psbtv2/psbtv2.ts
@@ -567,7 +567,7 @@ export class PsbtV2 extends PsbtV2Maps {
   /**
    * Unimplemented. Returns false.
    */
-  get isReadyForInputFinalizer(): boolean {
+  get isReadyForInputFinalizer() {
     // Checks to see if the psbt contains everything needed to finalize inputs.
     // This can become quite complicated considering multisig and taproot.
     console.warn(
@@ -586,7 +586,7 @@ export class PsbtV2 extends PsbtV2Maps {
    * details besides the UTXO. This getter checks that the Input Finalizer has
    * finished its job.
    */
-  get isReadyForTransactionExtractor(): boolean {
+  get isReadyForTransactionExtractor() {
     // Iterate over all inputs
 
     for (let i = 0; i < this.PSBT_GLOBAL_INPUT_COUNT; i++) {
@@ -618,21 +618,19 @@ export class PsbtV2 extends PsbtV2Maps {
       // here that it's safe to ignore the fact that those keys have not been
       // removed.
       if (
-        this.PSBT_IN_SIGHASH_TYPE[i] ||
-        this.PSBT_IN_SIGHASH_TYPE[i] === 0 ||
+        // Strings
         this.PSBT_IN_REDEEM_SCRIPT[i] ||
         this.PSBT_IN_WITNESS_SCRIPT[i] ||
         this.PSBT_IN_POR_COMMITMENT[i] ||
-        this.PSBT_IN_SEQUENCE[i] ||
-        this.PSBT_IN_SEQUENCE[i] === 0 ||
-        this.PSBT_IN_REQUIRED_TIME_LOCKTIME[i] ||
-        this.PSBT_IN_REQUIRED_TIME_LOCKTIME[i] === 0 ||
-        this.PSBT_IN_REQUIRED_HEIGHT_LOCKTIME[i] ||
-        this.PSBT_IN_REQUIRED_HEIGHT_LOCKTIME[i] === 0 ||
         this.PSBT_IN_TAP_KEY_SIG[i] ||
         this.PSBT_IN_TAP_INTERNAL_KEY[i] ||
         this.PSBT_IN_TAP_MERKLE_ROOT[i] ||
-        // Non-unique key types: Check the array for values
+        // Numbers
+        this.PSBT_IN_SIGHASH_TYPE[i] !== null ||
+        this.PSBT_IN_SEQUENCE[i] !== null ||
+        this.PSBT_IN_REQUIRED_TIME_LOCKTIME[i] !== null ||
+        this.PSBT_IN_REQUIRED_HEIGHT_LOCKTIME[i] !== null ||
+        // Arrays of non-unique keytype values
         this.PSBT_IN_PARTIAL_SIG[i].filter((el) => el !== null).length > 0 ||
         this.PSBT_IN_BIP32_DERIVATION[i].filter((el) => el !== null).length >
           0 ||


### PR DESCRIPTION
This change adds several getter methods to PsbtV2 to support operator role validation:
-  `get isReadyForConstructor`
-  `get isReadyForUpdater`
 -  `get isReadyForSigner`
-  `get isReadyForCombiner`
-  `get isReadyForInputFinalizer`
-  `get isReadyForTransactionExtractor`

These getters return `true` when the psbt is ready for actions by the role it is named after. `isReadyForInputFinalizer` has yet to be implemented. It is likely that the psbt may be ready for more than one role in any state.

These getters are used in a few public methods to validate that the psbt is ready for the role for which is responsible of the action. The methods will throw if the psbt is not ready for that role.
- `addInput`, `addOutput`, `deleteInput`, `deleteOutput`, and `dangerouslySetGlobalTxVersion1` checks `isReadyForConstructor`
- `addPartialSig` checks `isReadyForSigner`