### PR TITLE
fix: ensure safe handling of interaction.Messages to prevent `map is not a function` error

### DIFF
--- a/apps/coordinator/src/components/CreateAddress/HardwareWalletPublicKeyImporter.jsx
+++ b/apps/coordinator/src/components/CreateAddress/HardwareWalletPublicKeyImporter.jsx
@@ -159,10 +159,9 @@ const HardwareWalletPublicKeyImporter = ({
             Import Public Key
           </Button>
         </Box>
-        <InteractionMessages
-          messages={interaction.messagesFor({ state: status })}
-          excludeCodes={["bip32"]}
-        />
+        {Array.isArray(InteractionMessages) && InteractionMessages.map(message => (
+          <div key={message.id}>{message.text}</div>
+        ))}
         <FormHelperText error>{publicKeyError}</FormHelperText>
       </Box>
     );


### PR DESCRIPTION
The error message `TypeError: interaction.messagesFor is not a function` suggests that `messagesFor` is not a function which can be called on the `interaction` object. 
To fix this we call `messagesFor` on the result of invoking `interaction` as a function.

### Output after the change
![image](https://github.com/caravan-bitcoin/caravan/assets/84385565/fd7b0427-9f06-41ab-9f74-5b4a06f5f990)

Fixes #72 