### PR TITLE
fix: some build cleanup to avoid dependency

### DIFF
--- a/.changeset/funny-gorillas-destroy.md
+++ b/.changeset/funny-gorillas-destroy.md
@@ -1,0 +1,6 @@
+---
+"@caravan/psbt": patch
+"@caravan/wallets": patch
+---
+
+update caravan/multisig dependency to remove a "real" version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/package-lock.json
+++ b/package-lock.json
@@ -28458,7 +28458,7 @@
     },
     "packages/multisig": {
       "name": "@caravan/multisig",
-      "version": "2.0.0",
+      "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
         "@caravan/bitcoin": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.1",
         "prettier": "^3.1.1",
-        "turbo": "latest"
+        "turbo": "^2.0.3"
       },
       "engines": {
         "node": ">=20"
@@ -22891,26 +22891,26 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.12.2.tgz",
-      "integrity": "sha512-BcoQjBZ+LJCMdjzWhzQflOinUjek28rWXj07aaaAQ8T3Ehs0JFSjIsXOm4qIbo52G4xk3gFVcUtJhh/QRADl7g==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.0.3.tgz",
+      "integrity": "sha512-jF1K0tTUyryEWmgqk1V0ALbSz3VdeZ8FXUo6B64WsPksCMCE48N5jUezGOH2MN0+epdaRMH8/WcPU0QQaVfeLA==",
       "dev": true,
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.12.2",
-        "turbo-darwin-arm64": "1.12.2",
-        "turbo-linux-64": "1.12.2",
-        "turbo-linux-arm64": "1.12.2",
-        "turbo-windows-64": "1.12.2",
-        "turbo-windows-arm64": "1.12.2"
+        "turbo-darwin-64": "2.0.3",
+        "turbo-darwin-arm64": "2.0.3",
+        "turbo-linux-64": "2.0.3",
+        "turbo-linux-arm64": "2.0.3",
+        "turbo-windows-64": "2.0.3",
+        "turbo-windows-arm64": "2.0.3"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.12.2.tgz",
-      "integrity": "sha512-Aq/ePQ5KNx6XGwlZWTVTqpQYfysm1vkwkI6kAYgrX5DjMWn+tUXrSgNx4YNte0F+V4DQ7PtuWX+jRG0h0ZNg0A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.0.3.tgz",
+      "integrity": "sha512-v7ztJ8sxdHw3SLfO2MhGFeeU4LQhFii1hIGs9uBiXns/0YTGOvxLeifnfGqhfSrAIIhrCoByXO7nR9wlm10n3Q==",
       "cpu": [
         "x64"
       ],
@@ -22921,9 +22921,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.12.2.tgz",
-      "integrity": "sha512-wTr+dqkwJo/eXE+4SPTSeNBKyyfQJhI6I9sKVlCSBmtaNEqoGNgdVzgMUdqrg9AIFzLIiKO+zhfskNaSWpVFow==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.0.3.tgz",
+      "integrity": "sha512-LUcqvkV9Bxtng6QHbevp8IK8zzwbIxM6HMjCE7FEW6yJBN1KwvTtRtsGBwwmTxaaLO0wD1Jgl3vgkXAmQ4fqUw==",
       "cpu": [
         "arm64"
       ],
@@ -22934,9 +22934,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.12.2.tgz",
-      "integrity": "sha512-BggBKrLojGarDaa2zBo+kUR3fmjpd6bLA8Unm3Aa2oJw0UvEi3Brd+w9lNsPZHXXQYBUzNUY2gCdxf3RteWb0g==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.0.3.tgz",
+      "integrity": "sha512-xpdY1suXoEbsQsu0kPep2zrB8ijv/S5aKKrntGuQ62hCiwDFoDcA/Z7FZ8IHQ2u+dpJARa7yfiByHmizFE0r5Q==",
       "cpu": [
         "x64"
       ],
@@ -22947,9 +22947,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.12.2.tgz",
-      "integrity": "sha512-v/apSRvVuwYjq1D9MJFsHv2EpGd1S4VoSdZvVfW6FaM06L8CFZa92urNR1svdGYN28YVKwK9Ikc9qudC6t/d5A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.0.3.tgz",
+      "integrity": "sha512-MBACTcSR874L1FtLL7gkgbI4yYJWBUCqeBN/iE29D+8EFe0d3fAyviFlbQP4K/HaDYet1i26xkkOiWr0z7/V9A==",
       "cpu": [
         "arm64"
       ],
@@ -22960,9 +22960,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.12.2.tgz",
-      "integrity": "sha512-3uDdwXcRGkgopYFdPDpxQiuQjfQ12Fxq0fhj+iGymav0eWA4W4wzYwSdlUp6rT22qOBIzaEsrIspRwx1DsMkNg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.0.3.tgz",
+      "integrity": "sha512-zi3YuKPkM9JxMTshZo3excPk37hUrj5WfnCqh4FjI26ux6j/LJK+Dh3SebMHd9mR7wP9CMam4GhmLCT+gDfM+w==",
       "cpu": [
         "x64"
       ],
@@ -22973,9 +22973,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.12.2.tgz",
-      "integrity": "sha512-zNIHnwtQfJSjFi7movwhPQh2rfrcKZ7Xv609EN1yX0gEp9GxooCUi2yNnBQ8wTqFjioA2M5hZtGJQ0RrKaEm/Q==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.0.3.tgz",
+      "integrity": "sha512-wmed4kkenLvRbidi7gISB4PU77ujBuZfgVGDZ4DXTFslE/kYpINulwzkVwJIvNXsJtHqyOq0n6jL8Zwl3BrwDg==",
       "cpu": [
         "arm64"
       ],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.1",
     "prettier": "^3.1.1",
-    "turbo": "latest"
+    "turbo": "^2.0.3"
   },
   "dependencies": {
     "@ledgerhq/hw-transport-webusb": "6.27.12"
@@ -37,7 +37,7 @@
       "@ledgerhq/devices": "8.0.0"
     }
   },
-  "packageManager": "npm@10.2.3",
+  "packageManager": "npm@10.5.0",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "gen": "turbo gen run",
     "lint": "turbo lint",
-    "version": "turbo run build && turbo lint test && changeset version && npm install --package-lock-only",
-    "release": "turbo run build && turbo lint test && changeset publish",
+    "version": "turbo run build lint test && changeset version && npm install --package-lock-only",
+    "release": "turbo run build lint test && changeset publish",
     "dev:coordinator": "turbo run dev --filter=caravan-coordinator"
   },
   "devDependencies": {

--- a/packages/multisig/package.json
+++ b/packages/multisig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caravan/multisig",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "author": "unchained capital",
   "license": "MIT",
   "private": true,

--- a/turbo.json
+++ b/turbo.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": [
+        "^build"
+      ],
       "outputs": [
         "dist/**",
         "build/**"
@@ -11,7 +13,8 @@
     "lint": {},
     "test": {
       "dependsOn": [
-        "^build", "build"
+        "^build",
+        "build"
       ]
     },
     "test:debug": {
@@ -23,19 +26,28 @@
       ]
     },
     "dev": {
-      "dependsOn": ["^dev"],
+      "dependsOn": [
+        "^dev"
+      ],
       "cache": false,
       "persistent": true
-    }
-    ,
+    },
     "deploy": {
-      "dependsOn": ["build", "test", "lint"]
+      "dependsOn": [
+        "build",
+        "test",
+        "lint"
+      ]
     },
     "preview": {
-      "dependsOn": ["build"]
+      "dependsOn": [
+        "build"
+      ]
     },
     "ci": {
-      "dependsOn": ["^build"]
+      "dependsOn": [
+        "^build"
+      ]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -23,6 +23,7 @@
       ]
     },
     "dev": {
+      "dependsOn": ["^dev"],
       "cache": false,
       "persistent": true
     }


### PR DESCRIPTION
when trying to install one of the new packages (psbt or wallets) that depends on the internal package `@caravan/multisig`, I'm getting an error that the package can't be found in the registry. This shouldn't even be attempted. I'm not sure that this will fix it, but when looking at some turborepo examples, I did see that [internal packages](https://github.com/vercel/turbo/blob/main/examples/kitchen-sink/packages/logger/package.json) seem to have a version of `0.0.0` so maybe that will help. Included some other cleanup in the build processes that may or may not be related. 