### PR TITLE
upgrade more legacy psbt functions for s2tr

### DIFF
--- a/.changeset/large-pens-compete.md
+++ b/.changeset/large-pens-compete.md
@@ -1,0 +1,9 @@
+---
+"@caravan/psbt": minor
+"@caravan/wallets": patch
+"caravan-coordinator": minor
+---
+
+* caravan/psbt has new functions ported from caravan/bitcoin for legacy interactions with upgraded libs
+* caravan/wallets uses the upgraded versions of translatedPsbt to support taproot outputs
+* caravan coordinator now supports S2TR, better regtest support and other QoL improvements

--- a/package-lock.json
+++ b/package-lock.json
@@ -26032,6 +26032,7 @@
         "jest": "^29.4.1",
         "jsdom": "24.0.0",
         "jsdom-global": "3.0.2",
+        "lodash": "^4.17.21",
         "react-silence": "^1.0.4",
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",

--- a/packages/caravan-psbt/package.json
+++ b/packages/caravan-psbt/package.json
@@ -51,8 +51,8 @@
   "author": "unchained capital",
   "license": "ISC",
   "devDependencies": {
-    "@caravan/multisig": "*",
     "@caravan/eslint-config": "*",
+    "@caravan/multisig": "*",
     "@caravan/typescript-config": "*",
     "@inrupt/jest-jsdom-polyfills": "^3.2.1",
     "@jest/globals": "^29.7.0",
@@ -61,6 +61,7 @@
     "jest": "^29.4.1",
     "jsdom": "24.0.0",
     "jsdom-global": "3.0.2",
+    "lodash": "^4.17.21",
     "react-silence": "^1.0.4",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",

--- a/packages/caravan-psbt/src/psbtv0/psbt.test.ts
+++ b/packages/caravan-psbt/src/psbtv0/psbt.test.ts
@@ -2,12 +2,18 @@
  * @jest-environment  jsdom
  */
 
-import { TEST_FIXTURES } from "@caravan/bitcoin";
+import {
+  generateMultisigFromHex,
+  P2WSH,
+  ROOT_FINGERPRINT,
+  TEST_FIXTURES,
+} from "@caravan/bitcoin";
 import {
   getUnsignedMultisigPsbtV0,
   validateMultisigPsbtSignature,
+  translatePSBT,
 } from "./psbt";
-
+import _ from "lodash";
 import { psbtArgsFromFixture } from "./utils";
 
 describe("getUnsignedMultisigPsbtV0", () => {
@@ -41,7 +47,7 @@ describe("getUnsignedMultisigPsbtV0", () => {
   test("it can handle a taproot output", () => {
     const taprootAddress =
       "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c";
-    const fixture = TEST_FIXTURES.transactions[0];
+    const fixture = _.cloneDeep(TEST_FIXTURES.transactions[0]);
     let outputIndex;
     for (const [index, output] of fixture.outputs.entries()) {
       if (!output.redeemScript) {
@@ -91,4 +97,123 @@ describe("validateMultisigSignaturePsbt", () => {
         });
       });
     });
+});
+
+describe("translatePsbt", () => {
+  const MULTISIGS = TEST_FIXTURES.multisigs;
+  const TRANSACTIONS = TEST_FIXTURES.transactions;
+
+  const tx = _.cloneDeep(TEST_FIXTURES.transactions[0]);
+  const ms = MULTISIGS[0];
+
+  it("throws error with non-p2sh address type", () => {
+    expect(() =>
+      translatePSBT(
+        tx.network,
+        P2WSH,
+        // @ts-expect-error - we are testing an error case
+        {},
+        {
+          xfp: ROOT_FINGERPRINT,
+          path: "m/45'/1'/100'",
+        },
+      ),
+    ).toThrow(/Unsupported addressType/i);
+  });
+
+  it(`returns the inputs/outputs translated from the psbt`, () => {
+    const result = translatePSBT(tx.network, tx.format, tx.psbt, {
+      xfp: ROOT_FINGERPRINT,
+      path: "m/45'/1'/100'",
+    });
+    if (result) {
+      const { unchainedInputs, unchainedOutputs, bip32Derivations } = result;
+
+      // We can't compare directly because our fixtures contain
+      // additional information, so we will build our expected
+      // returned values from other parts of the fixtures while
+      // only sending in the psbt to the function we are testing.
+
+      // FIXME - this is specific to P2SH
+      const expectedInputs = tx.inputs.map((input) => ({
+        amountSats: input.value,
+        index: input.index,
+        transactionHex: input.transactionHex,
+        txid: input.txid,
+        multisig: generateMultisigFromHex(
+          tx.network,
+          tx.format,
+          ms.redeemScriptHex,
+        ),
+      }));
+      expect(unchainedInputs).toEqual(expectedInputs);
+
+      // Same as above, building expected object from a
+      // different set of data in the fixtures while the
+      // returned data is translated from the PSBT itself.
+      const expectedOutputs = tx.outputs.map((output) => ({
+        address: output.address,
+        amountSats: output.value,
+      }));
+
+      expect(unchainedOutputs).toEqual(expectedOutputs);
+
+      expect(bip32Derivations.map((b32d) => b32d.path)).toEqual(tx.bip32Paths);
+    }
+  });
+
+  it("should return null with non-string PSBT input", () => {
+    expect(
+      translatePSBT(
+        tx.network,
+        tx.format,
+        // @ts-expect-error - we are testing an error case
+        {},
+        {
+          xfp: ROOT_FINGERPRINT,
+          path: "m/45'/1'/100'",
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("should throw on psbt missing details (include psbt for another tx)", () => {
+    expect(() => {
+      translatePSBT(tx.network, tx.format, TRANSACTIONS[1].psbt, {
+        xfp: ROOT_FINGERPRINT,
+        path: "m/45'/1'/100'",
+      });
+    }).toThrow(/signing key details not included/i);
+  });
+
+  it("should handle a taproot output", () => {
+    const taprootAddress =
+      "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c";
+    const taprootTx = { ...tx };
+    taprootTx.outputs[0].address = taprootAddress;
+
+    const psbt = getUnsignedMultisigPsbtV0(psbtArgsFromFixture(taprootTx));
+
+    const result = translatePSBT(
+      taprootTx.network,
+      taprootTx.format,
+      psbt.toBase64(),
+      {
+        xfp: ROOT_FINGERPRINT,
+        path: "m/45'/1'/100'",
+      },
+    );
+    if (result) {
+      const { unchainedOutputs } = result;
+      let found = false;
+
+      for (const output of unchainedOutputs) {
+        if (output.address === taprootAddress) {
+          found = true;
+          break;
+        }
+      }
+      expect(found).toBe(true);
+    }
+  });
 });

--- a/packages/caravan-wallets/src/ledger.ts
+++ b/packages/caravan-wallets/src/ledger.ts
@@ -31,7 +31,6 @@ import {
   unsignedMultisigTransaction,
   validateBIP32Path,
   fingerprintToFixedLengthHex,
-  translatePSBT,
   addSignaturesToPSBT,
   BitcoinNetwork,
   validateHex,
@@ -39,7 +38,7 @@ import {
   PsbtV2,
   ExtendedPublicKey,
 } from "@caravan/bitcoin";
-
+import { translatePSBT } from "@caravan/psbt";
 import {
   ACTIVE,
   PENDING,

--- a/packages/caravan-wallets/src/trezor.ts
+++ b/packages/caravan-wallets/src/trezor.ts
@@ -36,10 +36,10 @@ import {
   networkData,
   validateBIP32Path,
   fingerprintToFixedLengthHex,
-  translatePSBT,
   addSignaturesToPSBT,
   Network,
 } from "@caravan/bitcoin";
+import { translatePSBT } from "@caravan/psbt";
 import { ECPair, payments, Payment } from "bitcoinjs-lib";
 
 import {
@@ -710,7 +710,9 @@ export class TrezorSignMultisigTransaction extends TrezorInteraction {
     } else {
       this.psbt = psbt;
       this.returnSignatureArray = returnSignatureArray || false;
-
+      if (typeof this.psbt !== "string") {
+        throw new Error("PSBT must be a string");
+      }
       const translatedPsbt = translatePSBT(
         network,
         P2SH,


### PR DESCRIPTION
a couple other functions that needed to be using bitcoinjs-lib v6 for taproot output support. previously this would cause an error in trezor signing if the interaction had a psbt and key details, then the old translatePSBT would result in an output without an address. 

In caravan coordinator there should be no change in functionality (i added an upgrade so that it would deploy and reflect the other s2tr changes in the prior PR on this subject), but it can be verified by changing the DirectSignatureImporter to pass a PSBT and keyDetails to the signing interaction. This will cause the TrezorSignMultisigTransaction to hit the code path that calls translatePSBT. With the old translatePSBT from `@caravan/bitcoin`, trezor-connect throws an error. 