### PR TITLE
Chore: bump coordinator

### DIFF
--- a/.changeset/mighty-spiders-matter.md
+++ b/.changeset/mighty-spiders-matter.md
@@ -1,0 +1,5 @@
+---
+"caravan-coordinator": patch
+---
+
+Include @caravan/wallets@0.2.2 and @caravan/psbt@1.3.2


### PR DESCRIPTION
Bump coordinator version so it includes [@caravan/wallets@0.2.2](https://github.com/caravan-bitcoin/caravan/releases/tag/%40caravan%2Fwallets%400.2.2) and [@caravan/psbt@1.3.2](https://github.com/caravan-bitcoin/caravan/releases/tag/%40caravan%2Fpsbt%401.3.2).