### PR TITLE
specify direct import

### DIFF
--- a/.changeset/seven-keys-matter.md
+++ b/.changeset/seven-keys-matter.md
@@ -1,0 +1,6 @@
+---
+"@caravan/psbt": patch
+"@caravan/wallets": patch
+---
+
+fixes an import issue when used in as an external dep

--- a/packages/caravan-psbt/src/psbtv0/psbt.ts
+++ b/packages/caravan-psbt/src/psbtv0/psbt.ts
@@ -12,7 +12,7 @@ import {
 } from "@caravan/bitcoin";
 import { Psbt, Transaction } from "bitcoinjs-lib-v6";
 import { MultisigWalletConfig } from "@caravan/multisig";
-import { toOutputScript } from "bitcoinjs-lib-v6/src/address";
+import { toOutputScript } from "bitcoinjs-lib-v6/src/address.js";
 import { GlobalXpub } from "bip174/src/lib/interfaces.js";
 // asmjs version is less performant than wasm version however
 // it should avoid any configuration challenges. If these can


### PR DESCRIPTION
Unclear to me why this wasn't picked up in the CI with #104, but this should fix an error when caravan/wallets or caravan/psbt are installed externally from the monorepo