### PR TITLE
add support for the BitBox02 hardware wallet

### DIFF
--- a/.changeset/heavy-kids-confess.md
+++ b/.changeset/heavy-kids-confess.md
@@ -1,0 +1,6 @@
+---
+"@caravan/wallets": minor
+"caravan-coordinator": minor
+---
+
+Add support for the BitBox02 hardware wallet

--- a/apps/coordinator/src/actions/keystoreActions.ts
+++ b/apps/coordinator/src/actions/keystoreActions.ts
@@ -1,10 +1,11 @@
-import { TREZOR, LEDGER, HERMIT, COLDCARD } from "@caravan/wallets";
+import { BITBOX, TREZOR, LEDGER, HERMIT, COLDCARD } from "@caravan/wallets";
 
 export const SET_KEYSTORE = "SET_KEYSTORE";
 export const SET_KEYSTORE_NOTE = "SET_KEYSTORE_NOTE";
 export const SET_KEYSTORE_STATUS = "SET_KEYSTORE_STATUS";
 
 type KeyStoreType =
+  | typeof BITBOX
   | typeof TREZOR
   | typeof LEDGER
   | typeof HERMIT

--- a/apps/coordinator/src/components/CreateAddress/HardwareWalletPublicKeyImporter.jsx
+++ b/apps/coordinator/src/components/CreateAddress/HardwareWalletPublicKeyImporter.jsx
@@ -6,6 +6,7 @@ import {
   ACTIVE,
   ERROR,
   ExportPublicKey,
+  BITBOX,
   TREZOR,
   LEDGER,
 } from "@caravan/wallets";
@@ -172,7 +173,7 @@ const HardwareWalletPublicKeyImporter = ({
 
 HardwareWalletPublicKeyImporter.propTypes = {
   network: PropTypes.string.isRequired,
-  method: PropTypes.oneOf([LEDGER, TREZOR]).isRequired,
+  method: PropTypes.oneOf([BITBOX, LEDGER, TREZOR]).isRequired,
   defaultBIP32Path: PropTypes.string.isRequired,
   validatePublicKey: PropTypes.func.isRequired,
   enableChangeMethod: PropTypes.func.isRequired,

--- a/apps/coordinator/src/components/CreateAddress/PublicKeyImporter.jsx
+++ b/apps/coordinator/src/components/CreateAddress/PublicKeyImporter.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { validatePublicKey as baseValidatePublicKey } from "@caravan/bitcoin";
-import { TREZOR, LEDGER } from "@caravan/wallets";
+import { BITBOX, TREZOR, LEDGER } from "@caravan/wallets";
 
 // Components
 import {
@@ -213,6 +213,7 @@ const PublicKeyImporter = ({
 
   const renderImportByMethod = () => {
     if (
+      publicKeyImporter.method === BITBOX ||
       publicKeyImporter.method === TREZOR ||
       publicKeyImporter.method === LEDGER
     ) {
@@ -261,6 +262,7 @@ const PublicKeyImporter = ({
             variant="standard"
           >
             <MenuItem value="">{"< Select method >"}</MenuItem>
+            <MenuItem value={BITBOX}>BitBox</MenuItem>
             <MenuItem value={TREZOR}>Trezor</MenuItem>
             <MenuItem value={LEDGER}>Ledger</MenuItem>
             <MenuItem value={XPUB}>Derive from extended public key</MenuItem>

--- a/apps/coordinator/src/components/RegisterWallet/RegisterBitBoxButton.jsx
+++ b/apps/coordinator/src/components/RegisterWallet/RegisterBitBoxButton.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from "react";
+import { Button } from "@mui/material";
+import { useDispatch, useSelector } from "react-redux";
+import { BITBOX, RegisterWalletPolicy } from "@caravan/wallets";
+import { getWalletConfig } from "../../selectors/wallet";
+import { setErrorNotification } from "../../actions/errorNotificationActions";
+
+const RegisterBitBoxButton = ({ ...otherProps }) => {
+  const [isActive, setIsActive] = useState(false);
+  const walletConfig = useSelector(getWalletConfig);
+  const dispatch = useDispatch();
+
+  const registerWallet = async () => {
+    setIsActive(true);
+    try {
+      const interaction = new RegisterWalletPolicy({
+        keystore: BITBOX,
+        ...walletConfig,
+      });
+      await interaction.run();
+    } catch (e) {
+      dispatch(setErrorNotification(e.message));
+    } finally {
+      setIsActive(false);
+    }
+  };
+  return (
+    <Button
+      variant="outlined"
+      onClick={registerWallet}
+      disabled={isActive}
+      {...otherProps}
+    >
+      Register w/ BitBox
+    </Button>
+  );
+};
+
+export default RegisterBitBoxButton;

--- a/apps/coordinator/src/components/RegisterWallet/index.jsx
+++ b/apps/coordinator/src/components/RegisterWallet/index.jsx
@@ -1,9 +1,11 @@
 import DownloadColdardConfigButton from "./DownloadColdcardConfig";
 import PolicyRegistrationTable from "./PolicyRegistrationsTable";
+import RegisterBitBoxButton from "./RegisterBitBoxButton";
 import RegisterLedgerButton from "./RegisterLedgerButton";
 
 export {
   DownloadColdardConfigButton,
   PolicyRegistrationTable,
+  RegisterBitBoxButton,
   RegisterLedgerButton,
 };

--- a/apps/coordinator/src/components/ScriptExplorer/SignatureImporter.jsx
+++ b/apps/coordinator/src/components/ScriptExplorer/SignatureImporter.jsx
@@ -8,7 +8,7 @@ import {
   validateBIP32Path,
   getMaskedDerivation,
 } from "@caravan/bitcoin";
-import { TREZOR, LEDGER, HERMIT, COLDCARD } from "@caravan/wallets";
+import { BITBOX, TREZOR, LEDGER, HERMIT, COLDCARD } from "@caravan/wallets";
 import {
   Card,
   CardHeader,
@@ -119,6 +119,7 @@ class SignatureImporter extends React.Component {
             onChange={this.handleMethodChange}
           >
             <MenuItem value={UNKNOWN}>{"< Select method >"}</MenuItem>
+            <MenuItem value={BITBOX}>BitBox</MenuItem>
             <MenuItem value={TREZOR}>Trezor</MenuItem>
             <MenuItem value={LEDGER}>Ledger</MenuItem>
             <MenuItem value={COLDCARD} disabled={!isWallet}>
@@ -155,7 +156,7 @@ class SignatureImporter extends React.Component {
     } = this.props;
     const { method } = signatureImporter;
 
-    if (method === TREZOR || method === LEDGER) {
+    if (method === BITBOX || method === TREZOR || method === LEDGER) {
       return (
         <DirectSignatureImporter
           network={network}

--- a/apps/coordinator/src/components/ScriptExplorer/SignatureImporter.jsx
+++ b/apps/coordinator/src/components/ScriptExplorer/SignatureImporter.jsx
@@ -7,6 +7,7 @@ import {
   multisigBIP32Root,
   validateBIP32Path,
   getMaskedDerivation,
+  P2SH,
 } from "@caravan/bitcoin";
 import { BITBOX, TREZOR, LEDGER, HERMIT, COLDCARD } from "@caravan/wallets";
 import {
@@ -93,7 +94,7 @@ class SignatureImporter extends React.Component {
   };
 
   renderImport = () => {
-    const { signatureImporter, number, isWallet } = this.props;
+    const { signatureImporter, number, isWallet, addressType } = this.props;
     const currentNumber = this.getCurrent();
     const notMyTurn = number > currentNumber;
     const { disableChangeMethod } = this.state;
@@ -119,7 +120,7 @@ class SignatureImporter extends React.Component {
             onChange={this.handleMethodChange}
           >
             <MenuItem value={UNKNOWN}>{"< Select method >"}</MenuItem>
-            <MenuItem value={BITBOX}>BitBox</MenuItem>
+            {addressType != P2SH && <MenuItem value={BITBOX}>BitBox</MenuItem>}
             <MenuItem value={TREZOR}>Trezor</MenuItem>
             <MenuItem value={LEDGER}>Ledger</MenuItem>
             <MenuItem value={COLDCARD} disabled={!isWallet}>

--- a/apps/coordinator/src/components/Slices/ConfirmAddress.jsx
+++ b/apps/coordinator/src/components/Slices/ConfirmAddress.jsx
@@ -23,6 +23,7 @@ import {
   multisigTotalSigners,
 } from "@caravan/bitcoin";
 import {
+  BITBOX,
   TREZOR,
   LEDGER,
   COLDCARD,
@@ -138,6 +139,7 @@ const ConfirmAddress = ({ slice, network }) => {
       }
       // FIXME - hardcoded to just show up for trezor
       if (
+        extendedPublicKeyImporter.method === BITBOX ||
         extendedPublicKeyImporter.method === TREZOR ||
         extendedPublicKeyImporter.method === LEDGER
       ) {
@@ -230,6 +232,7 @@ const ConfirmAddress = ({ slice, network }) => {
               variant="standard"
             >
               <MenuItem value="">{"< Select method >"}</MenuItem>
+              <MenuItem value={BITBOX}>BitBox</MenuItem>
               <MenuItem value={TREZOR}>Trezor</MenuItem>
               <MenuItem value={LEDGER}>Ledger</MenuItem>
               <MenuItem value={COLDCARD} disabled>

--- a/apps/coordinator/src/components/Slices/ConfirmAddress.jsx
+++ b/apps/coordinator/src/components/Slices/ConfirmAddress.jsx
@@ -21,6 +21,7 @@ import {
   multisigAddressType,
   multisigRequiredSigners,
   multisigTotalSigners,
+  P2SH,
 } from "@caravan/bitcoin";
 import {
   BITBOX,
@@ -232,7 +233,9 @@ const ConfirmAddress = ({ slice, network }) => {
               variant="standard"
             >
               <MenuItem value="">{"< Select method >"}</MenuItem>
-              <MenuItem value={BITBOX}>BitBox</MenuItem>
+              {addressType != P2SH && (
+                <MenuItem value={BITBOX}>BitBox</MenuItem>
+              )}
               <MenuItem value={TREZOR}>Trezor</MenuItem>
               <MenuItem value={LEDGER}>Ledger</MenuItem>
               <MenuItem value={COLDCARD} disabled>

--- a/apps/coordinator/src/components/TestSuiteRun/KeystorePicker.tsx
+++ b/apps/coordinator/src/components/TestSuiteRun/KeystorePicker.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { connect } from "react-redux";
 
 import {
+  BITBOX,
   TREZOR,
   LEDGER,
   HERMIT,
@@ -89,6 +90,7 @@ const KeystorePickerBase = ({
               variant="standard"
             >
               <MenuItem value="">{"< Select type >"}</MenuItem>
+              <MenuItem value={BITBOX}>BitBox</MenuItem>
               <MenuItem value={TREZOR}>Trezor</MenuItem>
               <MenuItem value={LEDGER}>Ledger</MenuItem>
               <MenuItem value={COLDCARD}>Coldcard</MenuItem>

--- a/apps/coordinator/src/components/TestSuiteRun/TestSuiteRunSummary.tsx
+++ b/apps/coordinator/src/components/TestSuiteRun/TestSuiteRunSummary.tsx
@@ -3,6 +3,7 @@ import moment from "moment";
 import { useSelector, useDispatch } from "react-redux";
 import Bowser from "bowser";
 import {
+  BITBOX,
   TREZOR,
   LEDGER,
   HERMIT,
@@ -178,6 +179,8 @@ const TestSuiteRunSummaryBase = () => {
 
   const keystoreName = (type: string) => {
     switch (type) {
+      case BITBOX:
+        return "BitBox";
       case TREZOR:
         return "Trezor";
       case LEDGER:

--- a/apps/coordinator/src/components/Wallet/ExtendedPublicKeyImporter.jsx
+++ b/apps/coordinator/src/components/Wallet/ExtendedPublicKeyImporter.jsx
@@ -7,6 +7,7 @@ import {
   convertExtendedPublicKey,
   validateExtendedPublicKey,
   Network,
+  P2SH,
 } from "@caravan/bitcoin";
 import { BITBOX, TREZOR, LEDGER, HERMIT, COLDCARD } from "@caravan/wallets";
 import {
@@ -68,7 +69,7 @@ class ExtendedPublicKeyImporter extends React.Component {
   };
 
   renderImport = () => {
-    const { extendedPublicKeyImporter, number } = this.props;
+    const { extendedPublicKeyImporter, number, addressType } = this.props;
     const { disableChangeMethod } = this.state;
     return (
       <div>
@@ -82,7 +83,7 @@ class ExtendedPublicKeyImporter extends React.Component {
             variant="standard"
             onChange={this.handleMethodChange}
           >
-            <MenuItem value={BITBOX}>BitBox</MenuItem>
+            {addressType != P2SH && <MenuItem value={BITBOX}>BitBox</MenuItem>}
             <MenuItem value={TREZOR}>Trezor</MenuItem>
             <MenuItem value={COLDCARD}>Coldcard</MenuItem>
             <MenuItem value={LEDGER}>Ledger</MenuItem>

--- a/apps/coordinator/src/components/Wallet/ExtendedPublicKeyImporter.jsx
+++ b/apps/coordinator/src/components/Wallet/ExtendedPublicKeyImporter.jsx
@@ -8,7 +8,7 @@ import {
   validateExtendedPublicKey,
   Network,
 } from "@caravan/bitcoin";
-import { TREZOR, LEDGER, HERMIT, COLDCARD } from "@caravan/wallets";
+import { BITBOX, TREZOR, LEDGER, HERMIT, COLDCARD } from "@caravan/wallets";
 import {
   Card,
   CardHeader,
@@ -82,6 +82,7 @@ class ExtendedPublicKeyImporter extends React.Component {
             variant="standard"
             onChange={this.handleMethodChange}
           >
+            <MenuItem value={BITBOX}>BitBox</MenuItem>
             <MenuItem value={TREZOR}>Trezor</MenuItem>
             <MenuItem value={COLDCARD}>Coldcard</MenuItem>
             <MenuItem value={LEDGER}>Ledger</MenuItem>
@@ -105,7 +106,7 @@ class ExtendedPublicKeyImporter extends React.Component {
     } = this.props;
     const { method } = extendedPublicKeyImporter;
 
-    if (method === TREZOR || method === LEDGER) {
+    if (method === BITBOX || method === TREZOR || method === LEDGER) {
       return (
         <DirectExtendedPublicKeyImporter
           extendedPublicKeyImporter={extendedPublicKeyImporter}

--- a/apps/coordinator/src/components/Wallet/RegisterWallet.jsx
+++ b/apps/coordinator/src/components/Wallet/RegisterWallet.jsx
@@ -19,6 +19,7 @@ import { getWalletConfig } from "../../selectors/wallet";
 import PolicyRegistrationTable from "../RegisterWallet/PolicyRegistrationsTable";
 import {
   DownloadColdardConfigButton,
+  RegisterBitBoxButton,
   RegisterLedgerButton,
 } from "../RegisterWallet";
 
@@ -89,6 +90,9 @@ const WalletRegistrations = () => {
         <AccordionDetails>
           <Box>
             <Grid container spacing={2}>
+              <Grid item>
+                <RegisterBitBoxButton />
+              </Grid>
               <Grid item>
                 <RegisterLedgerButton />
               </Grid>

--- a/apps/coordinator/src/components/Wallet/index.jsx
+++ b/apps/coordinator/src/components/Wallet/index.jsx
@@ -150,6 +150,7 @@ class CreateWallet extends React.Component {
       method: (method, index) => {
         if (
           [
+            "bitbox",
             "trezor",
             "coldcard",
             "ledger",

--- a/apps/coordinator/src/tests/bitbox.js
+++ b/apps/coordinator/src/tests/bitbox.js
@@ -1,0 +1,13 @@
+import { BITBOX } from "@caravan/wallets";
+
+import publicKeyTests from "./publicKeys";
+import extendedPublicKeyTests from "./extendedPublicKeys";
+import { signingTests } from "./signing";
+import addressTests from "./addresses";
+import registrationTests from "./registration";
+
+export default publicKeyTests(BITBOX)
+  .concat(extendedPublicKeyTests(BITBOX))
+  .concat(signingTests(BITBOX))
+  .concat(addressTests(BITBOX))
+  .concat(registrationTests(BITBOX));

--- a/apps/coordinator/src/tests/index.js
+++ b/apps/coordinator/src/tests/index.js
@@ -1,6 +1,7 @@
-import { TREZOR, LEDGER, HERMIT, COLDCARD } from "@caravan/wallets";
+import { BITBOX, TREZOR, LEDGER, HERMIT, COLDCARD } from "@caravan/wallets";
 import { TEST_FIXTURES } from "@caravan/bitcoin";
 
+import bitboxTests from "./bitbox";
 import trezorTests from "./trezor";
 import ledgerTests from "./ledger";
 import hermitTests from "./hermit";
@@ -8,6 +9,7 @@ import coldcardTests from "./coldcard";
 
 const SUITE = {};
 
+SUITE[BITBOX] = bitboxTests;
 SUITE[TREZOR] = trezorTests;
 SUITE[LEDGER] = ledgerTests;
 SUITE[HERMIT] = hermitTests;

--- a/apps/coordinator/src/tests/registration.jsx
+++ b/apps/coordinator/src/tests/registration.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { TEST_FIXTURES } from "@caravan/bitcoin";
-import { RegisterWalletPolicy } from "@caravan/wallets";
+import { BITBOX, RegisterWalletPolicy } from "@caravan/wallets";
 import { Box, Table, TableBody, TableRow, TableCell } from "@mui/material";
 
 import Test from "./Test";
@@ -13,6 +13,10 @@ class RegisterWalletPolicyTest extends Test {
   }
 
   expected() {
+    if (this.params.keystore === BITBOX) {
+      // BitBox does not use HMACs to register policies.
+      return undefined;
+    }
     return this.params.policyHmac;
   }
 

--- a/apps/coordinator/src/tests/signing.jsx
+++ b/apps/coordinator/src/tests/signing.jsx
@@ -8,6 +8,7 @@ import {
   TEST_FIXTURES,
 } from "@caravan/bitcoin";
 import {
+  BITBOX,
   COLDCARD,
   HERMIT,
   LEDGER,
@@ -193,6 +194,17 @@ export function signingTests(keystore) {
         }
       });
       return transactions;
+    case BITBOX:
+      return TEST_FIXTURES.transactions
+        .filter((fixture) => fixture.braidDetails)
+        .map(
+          (fixture) =>
+            new SignMultisigTransactionTest({
+              ...fixture,
+              ...{ keystore },
+              returnSignatureArray: true,
+            }),
+        );
     case LEDGER:
       return TEST_FIXTURES.transactions
         .filter((fixture) => fixture.policyHmac && fixture.braidDetails)

--- a/apps/coordinator/vite.config.ts
+++ b/apps/coordinator/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     }),
   ],
   build: {
+    target: "esnext", // browsers can handle the latest ES features
     outDir: "build",
     rollupOptions: {
       onwarn(warning, warn) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8972,12 +8972,6 @@
         "node": ">=4.5.0"
       }
     },
-    "node_modules/bitbox-api": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/bitbox-api/-/bitbox-api-0.6.0.tgz",
-      "integrity": "sha512-9JG5zzjP2GgYlSpgC2nq/5CQGAOCS0Jni/DwpH1byLyx6aCvKY7SNqsr8R/AREKoqe7/D7XIrC1a8eABapdG1A==",
-      "dev": true
-    },
     "node_modules/bitcoin-address-validation": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bitcoin-address-validation/-/bitcoin-address-validation-1.0.2.tgz",
@@ -28102,7 +28096,7 @@
         "@typescript-eslint/parser": "^5.51.0",
         "babel-jest": "^29.7.0",
         "babel-plugin-transform-inline-environment-variables": "^0.4.3",
-        "bitbox-api": "^0.6.0",
+        "bitbox-api": "^0.7.0",
         "esbuild-plugin-polyfill-node": "^0.3.0",
         "eslint": "^8.34.0",
         "eslint-plugin-import": "^2.27.5",
@@ -28458,6 +28452,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "packages/caravan-wallets/node_modules/bitbox-api": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/bitbox-api/-/bitbox-api-0.7.0.tgz",
+      "integrity": "sha512-uoE6MEV+KyAeX9+P/Gf7ujVFgy1eJWfnpd3Z8n8QXk4OgXha81x3O9PwN1XJv8zcNFUekS1OfsI/yJWvPbQysg==",
+      "dev": true
     },
     "packages/caravan-wallets/node_modules/brace-expansion": {
       "version": "1.1.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8972,6 +8972,12 @@
         "node": ">=4.5.0"
       }
     },
+    "node_modules/bitbox-api": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/bitbox-api/-/bitbox-api-0.6.0.tgz",
+      "integrity": "sha512-9JG5zzjP2GgYlSpgC2nq/5CQGAOCS0Jni/DwpH1byLyx6aCvKY7SNqsr8R/AREKoqe7/D7XIrC1a8eABapdG1A==",
+      "dev": true
+    },
     "node_modules/bitcoin-address-validation": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bitcoin-address-validation/-/bitcoin-address-validation-1.0.2.tgz",
@@ -28096,6 +28102,7 @@
         "@typescript-eslint/parser": "^5.51.0",
         "babel-jest": "^29.7.0",
         "babel-plugin-transform-inline-environment-variables": "^0.4.3",
+        "bitbox-api": "^0.6.0",
         "esbuild-plugin-polyfill-node": "^0.3.0",
         "eslint": "^8.34.0",
         "eslint-plugin-import": "^2.27.5",

--- a/packages/caravan-wallets/package.json
+++ b/packages/caravan-wallets/package.json
@@ -51,7 +51,7 @@
     "@typescript-eslint/parser": "^5.51.0",
     "babel-jest": "^29.7.0",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
-    "bitbox-api": "^0.6.0",
+    "bitbox-api": "^0.7.0",
     "esbuild-plugin-polyfill-node": "^0.3.0",
     "eslint": "^8.34.0",
     "eslint-plugin-import": "^2.27.5",

--- a/packages/caravan-wallets/package.json
+++ b/packages/caravan-wallets/package.json
@@ -51,6 +51,7 @@
     "@typescript-eslint/parser": "^5.51.0",
     "babel-jest": "^29.7.0",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
+    "bitbox-api": "^0.6.0",
     "esbuild-plugin-polyfill-node": "^0.3.0",
     "eslint": "^8.34.0",
     "eslint-plugin-import": "^2.27.5",

--- a/packages/caravan-wallets/src/bitbox.ts
+++ b/packages/caravan-wallets/src/bitbox.ts
@@ -1,0 +1,467 @@
+/*** This module provides classes for BitBox hardware wallets.
+ *
+ * The following API classes are implemented:
+ *
+ * * BitBoxGetMetadata
+ * * BitBoxExportPublicKey
+ * * BitBoxExportExtendedPublicKey
+ * * BitBoxSignMultisigTransaction
+ */
+
+import {
+  BitcoinNetwork,
+  getPsbtVersionNumber,
+  PsbtV2,
+  ExtendedPublicKey,
+  MultisigAddressType,
+} from "@caravan/bitcoin";
+import {
+  ACTIVE,
+  PENDING,
+  INFO,
+  DirectKeystoreInteraction,
+} from "./interaction";
+
+import { MultisigWalletConfig } from "./types";
+
+import {
+  BtcCoin,
+  BtcMultisigScriptType,
+  BtcScriptConfig,
+  PairedBitBox,
+} from 'bitbox-api';
+
+/**
+ * Constant defining BitBox interactions.
+ */
+export const BITBOX = "bitbox";
+
+function convertNetwork(network: BitcoinNetwork): BtcCoin {
+  return network === 'mainnet' ? 'btc' : 'tbtc';
+}
+
+function convertToBtcMultisigScriptType(addressType: MultisigAddressType): BtcMultisigScriptType {
+  switch (addressType) {
+    case 'P2WSH':
+      return 'p2wsh';
+    case 'P2SH-P2WSH':
+      return 'p2wshP2sh';
+    default:
+      throw new Error(`BitBox does not support ${addressType} multisig.`);
+  }
+}
+
+async function convertMultisig(pairedBitBox: PairedBitBox, walletConfig: MultisigWalletConfig): Promise<{ scriptConfig: BtcScriptConfig; keypathAccount: string; }> {
+  const ourRootFingerprint = await pairedBitBox.rootFingerprint();
+
+  const ourXpubIndex = walletConfig.extendedPublicKeys.findIndex(key => key.xfp == ourRootFingerprint);
+  if (ourXpubIndex === -1) {
+    throw new Error('This BitBox02 seems to not be present in the multisig quorum.');
+  }
+  const scriptConfig = {
+    multisig: {
+      threshold: walletConfig.quorum.requiredSigners,
+      scriptType: convertToBtcMultisigScriptType(walletConfig.addressType),
+      xpubs: walletConfig.extendedPublicKeys.map(key => key.xpub),
+      ourXpubIndex,
+    },
+  };
+  const keypathAccount = walletConfig.extendedPublicKeys[ourXpubIndex].bip32Path;
+  return {
+    scriptConfig,
+    keypathAccount,
+  }
+}
+
+/**
+ * Base class for interactions with BitBox hardware wallets.
+ *
+ * Subclasses must implement their own `run()` method.  They may use
+ * the `withDevice` method to connect to the BitBox API.
+ *
+ * @example
+ * import {BitBoxInteraction} from "@caravan/wallets";
+ * // Simple subclass
+ *
+ * class SimpleBitBoxInteraction extends BitBoxInteraction {
+ *
+ *   constructor({param}) {
+ *     super({});
+ *     this.param =  param;
+ *   }
+ *
+ *   async run() {
+ *     return await this.withDevice(async (pairedBitBox) => {
+ *       return pairedBitBox.doSomething(this.param); // Not a real BitBox API call
+ *     });
+ *   }
+ *
+ * }
+ *
+ * // usage
+ * const interaction = new SimpleBitBoxInteraction({param: "foo"});
+ * const result = await interaction.run();
+ * console.log(result); // whatever value `app.doSomething(...)` returns
+ *
+ */
+export class BitBoxInteraction extends DirectKeystoreInteraction {
+  appVersion?: string;
+
+  appName?: string;
+
+  /**
+   * Adds `pending` messages at the `info` level about ensuring the
+   * device is plugged in (`device.connect`) and unlocked
+   * (`device.unlock`).  Adds an `active` message at the `info` level
+   * when communicating with the device (`device.active`).
+   */
+  messages() {
+    const messages = super.messages();
+    messages.push({
+      state: PENDING,
+      level: INFO,
+      text: "Please plug in your BitBox.",
+      code: "device.setup",
+    });
+    messages.push({
+      state: ACTIVE,
+      level: INFO,
+      text: "Communicating with BitBox...",
+      code: "device.active",
+    });
+    return messages;
+  }
+
+  async withDevice<T>(f: (device: PairedBitBox) => Promise<T>): Promise<T> {
+    const bitbox = await import('bitbox-api');
+
+    try {
+      const unpaired = await bitbox.bitbox02ConnectAuto(() => {
+      })
+      const pairing = await unpaired.unlockAndPair()
+      const pairingCode = pairing.getPairingCode()
+      if (pairingCode) {
+        // TODO: display pairing code to the user.
+        console.log('Pairing code:', pairingCode);
+      }
+      const pairedBitBox = await pairing.waitConfirm()
+      try {
+        return await f(pairedBitBox)
+      } finally {
+        pairedBitBox.close()
+      }
+    } catch (err) {
+      const typedErr = bitbox.ensureError(err)
+      const isErrorUnknown = typedErr.code === 'unknown-js'
+      const errorMessage = isErrorUnknown ? typedErr.err! : typedErr.message
+      throw new Error(errorMessage);
+    } finally {
+      // TODO hide pairing code if still shown.
+    }
+  }
+
+  async maybeRegisterMultisig(pairedBitBox: PairedBitBox, walletConfig: MultisigWalletConfig): Promise<{ scriptConfig: BtcScriptConfig, keypathAccount: string; }> {
+    const { scriptConfig, keypathAccount } = await convertMultisig(pairedBitBox, walletConfig);
+    const isRegistered = await pairedBitBox.btcIsScriptConfigRegistered(
+      convertNetwork(walletConfig.network),
+      scriptConfig,
+      keypathAccount,
+    );
+    // No name means the user inputs it on the device.
+    // eslint-disable-next-line no-undefined
+    const name = undefined;
+    if (!isRegistered) {
+      await pairedBitBox.btcRegisterScriptConfig(
+        convertNetwork(walletConfig.network),
+        scriptConfig,
+        keypathAccount,
+        'autoXpubTpub',
+        name,
+      );
+    }
+    return { scriptConfig, keypathAccount };
+  }
+
+  // Dummy to satsify the return types of all subclass run() functions.
+  async run(): Promise<any> {
+  }
+}
+
+/**
+ * Returns metadata about the BitBox device.
+ *
+ * @example
+ * import {BitBoxGetMetadata} from "@caravan/wallets";
+ * const interaction = new BitBoxGetMetadata();
+ * const result = await interaction.run();
+ * console.log(result);
+ * {
+ *   spec: "bitbox02-btconly 9.18.0",
+ *   version: {
+ *     major: "9",
+ *     minor: "18",
+ *     patch: "0",
+ *     string: "9.18.0"",
+ *   },
+
+ *   model: "bitbox02-btconly",
+ * }
+ *
+ */
+export class BitBoxGetMetadata extends BitBoxInteraction {
+  async run() {
+    return this.withDevice(async (pairedBitBox) => {
+      const product = pairedBitBox.product();
+      const version = pairedBitBox.version();
+      const [majorVersion, minorVersion, patchVersion] = (version || "").split(
+        "."
+      );
+      return {
+        spec: `${product} v${version}`,
+        version: {
+          major: majorVersion,
+          minor: minorVersion,
+          patch: patchVersion,
+          string: version,
+        },
+        model: product,
+      };
+    });
+  }
+}
+
+/**
+ * Class for public key interaction at a given BIP32 path.
+ */
+export class BitBoxExportPublicKey extends BitBoxInteraction {
+  network: BitcoinNetwork;
+
+  bip32Path: string;
+
+  includeXFP: boolean;
+
+  /**
+   * @param {string} bip32Path path
+   * @param {boolean} includeXFP - return xpub with root fingerprint concatenated
+   */
+  constructor({ network, bip32Path, includeXFP }) {
+    super();
+    this.network = network;
+    this.bip32Path = bip32Path;
+    this.includeXFP = includeXFP;
+  }
+
+  messages() {
+    return super.messages();
+  }
+
+  /**
+   * Retrieve the compressed public key for a given BIP32 path
+   */
+  async run() {
+    return await this.withDevice(async (pairedBitBox) => {
+      const xpub = await pairedBitBox.btcXpub(
+        convertNetwork(this.network),
+        this.bip32Path,
+        this.network === 'mainnet' ? 'xpub' : 'tpub',
+        false);
+      const publicKey = ExtendedPublicKey.fromBase58(xpub).pubkey;
+      if (this.includeXFP) {
+        const rootFingerprint = await pairedBitBox.rootFingerprint();
+        return { publicKey, rootFingerprint };
+      }
+      return publicKey;
+    });
+  }
+}
+
+/**
+ * Class for wallet extended public key (xpub) interaction at a given BIP32 path.
+ */
+export class BitBoxExportExtendedPublicKey extends BitBoxInteraction {
+  bip32Path: string;
+
+  network: BitcoinNetwork;
+
+  includeXFP: boolean;
+
+  /**
+   * @param {string} bip32Path path
+   * @param {string} network bitcoin network
+   * @param {boolean} includeXFP - return xpub with root fingerprint concatenated
+   */
+  constructor({ bip32Path, network, includeXFP }) {
+    super();
+    this.bip32Path = bip32Path;
+    this.network = network;
+    this.includeXFP = includeXFP;
+  }
+
+  messages() {
+    return super.messages();
+  }
+
+  /**
+   * Retrieve extended public key (xpub) from BitBox device for a given BIP32 path
+   * @example
+   * import {BitBoxExportExtendedPublicKey} from "@caravan/wallets";
+   * const interaction = new BitBoxExportExtendedPublicKey({network, bip32Path});
+   * const xpub = await interaction.run();
+   * console.log(xpub);
+   */
+  async run() {
+    return await this.withDevice(async (pairedBitBox) => {
+      const xpub = await pairedBitBox.btcXpub(
+        convertNetwork(this.network),
+        this.bip32Path,
+        this.network === 'mainnet' ? 'xpub' : 'tpub',
+        false);
+      if (this.includeXFP) {
+        const rootFingerprint = await pairedBitBox.rootFingerprint();
+        return { xpub, rootFingerprint };
+      }
+      return xpub;
+    });
+  }
+}
+
+export class BitBoxRegisterWalletPolicy extends BitBoxInteraction {
+  walletConfig: MultisigWalletConfig;
+
+  constructor({
+    walletConfig
+  }: { walletConfig: MultisigWalletConfig}) {
+    super();
+    this.walletConfig = walletConfig;
+  }
+
+  messages() {
+    const messages = super.messages();
+    return messages;
+  }
+
+  async run() {
+    return await this.withDevice(async (pairedBitBox) => {
+      await this.maybeRegisterMultisig(pairedBitBox, this.walletConfig);
+      // BitBox does not use HMACs for registrations, so we we don't return anything here.
+    });
+  }
+}
+
+export class BitBoxConfirmMultisigAddress extends BitBoxInteraction {
+  network: BitcoinNetwork;
+
+  bip32Path: string;
+
+  walletConfig: MultisigWalletConfig;
+
+  constructor({ network, bip32Path, walletConfig }) {
+    super();
+    this.network = network;
+    this.bip32Path = bip32Path;
+    this.walletConfig = walletConfig;
+  }
+
+  /**
+   * Adds messages about BIP32 path warnings.
+   */
+  messages() {
+    const messages = super.messages();
+    return messages;
+  }
+
+  async run() {
+    const display = true;
+    return await this.withDevice(async (pairedBitBox) => {
+      const { scriptConfig } = await this.maybeRegisterMultisig(pairedBitBox, this.walletConfig);
+      const address = await pairedBitBox.btcAddress(
+        convertNetwork(this.network),
+        this.bip32Path,
+        scriptConfig,
+        display,
+      );
+      return {
+        address,
+        serializedPath: this.bip32Path,
+      };
+    });
+  }
+}
+
+function parsePsbt(psbt: string): PsbtV2 {
+  const psbtVersion = getPsbtVersionNumber(psbt);
+  switch (psbtVersion) {
+    case 0:
+      return PsbtV2.FromV0(psbt, true);
+    case 2:
+      return new PsbtV2(psbt);
+    default:
+      throw new Error(`PSBT of unsupported version ${psbtVersion}`);
+  }
+}
+
+export class BitBoxSignMultisigTransaction extends BitBoxInteraction {
+  private walletConfig: MultisigWalletConfig;
+
+  private returnSignatureArray: boolean;
+
+  // keeping this until we have a way to add signatures to psbtv2 directly
+  // this will store the the PSBT that was was passed in via args
+  private unsignedPsbt: string;
+
+  constructor({
+    walletConfig,
+    psbt,
+    returnSignatureArray = false,
+  }) {
+    super();
+    this.walletConfig = walletConfig;
+    this.returnSignatureArray = returnSignatureArray;
+
+    this.unsignedPsbt = Buffer.isBuffer(psbt) ? psbt.toString("base64") : psbt;
+  }
+
+  async run() {
+    return await this.withDevice(async (pairedBitBox) => {
+      const { scriptConfig, keypathAccount } = await this.maybeRegisterMultisig(pairedBitBox, this.walletConfig);
+      const signedPsbt = await pairedBitBox.btcSignPSBT(
+        convertNetwork(this.walletConfig.network),
+        this.unsignedPsbt,
+        {
+          scriptConfig,
+          keypath: keypathAccount,
+        },
+        'default',
+      );
+      if (this.returnSignatureArray) {
+        // Extract the sigs for that belong to us (identified by the root fingerprint).
+        // This only works reliably if the fingerprint is unique, i.e. all signers have different
+        // fingerprints.
+        const ourRootFingerprint = await pairedBitBox.rootFingerprint();
+        const parsedPsbt = parsePsbt(signedPsbt);
+        let sigArray: string[] = [];
+        for (let i = 0; i < parsedPsbt.PSBT_GLOBAL_INPUT_COUNT; i++) {
+          const bip32Derivations = parsedPsbt.PSBT_IN_BIP32_DERIVATION[i];
+          if (!Array.isArray(bip32Derivations)) {
+            throw new Error('bip32 derivations expected to be an array');
+          }
+          const bip32Derivation = bip32Derivations.find(entry => entry.value!.substr(0, 8) == ourRootFingerprint);
+          if (!bip32Derivation) {
+            throw new Error('could not find our pubkey in the signed PSBT');
+          }
+          // First byte of the key is 0x06, the PSBT key.
+          const pubKey = bip32Derivation.key.substr(2);
+          // First byte of the key is 0x02, the PSBT key.
+          const partialSig = parsedPsbt.PSBT_IN_PARTIAL_SIG[i].find(e => e.key.substr(2) === pubKey);
+          if (!partialSig) {
+            throw new Error('could not find our signature in the signed PSBT');
+          }
+          sigArray.push(partialSig.value!);
+        }
+
+        return sigArray;
+      }
+      return signedPsbt;
+    });
+  }
+}

--- a/packages/caravan-wallets/src/bitbox.ts
+++ b/packages/caravan-wallets/src/bitbox.ts
@@ -40,7 +40,14 @@ export const BITBOX = "bitbox";
 export type TShowPairingCode = (pairingCode: string) => (() => void) | null;
 
 function convertNetwork(network: BitcoinNetwork): BtcCoin {
-  return network === 'mainnet' ? 'btc' : 'tbtc';
+  switch (network) {
+    case 'mainnet':
+      return 'btc';
+    case 'regtest':
+      return 'rbtc';
+    default:
+      return 'tbtc';
+  }
 }
 
 function convertToBtcMultisigScriptType(addressType: MultisigAddressType): BtcMultisigScriptType {

--- a/packages/caravan-wallets/src/index.ts
+++ b/packages/caravan-wallets/src/index.ts
@@ -115,7 +115,7 @@ export type KEYSTORE_TYPES = (typeof KEYSTORES)[KEYSTORE_KEYS];
 export function GetMetadata({ keystore }: { keystore: KEYSTORE_TYPES }) {
   switch (keystore) {
     case BITBOX:
-      return new BitBoxGetMetadata();
+      return new BitBoxGetMetadata({});
     case LEDGER:
       return new LedgerGetMetadata();
     case TREZOR:

--- a/packages/caravan-wallets/tsconfig.json
+++ b/packages/caravan-wallets/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     // be explicit about the root directory of the project
     "rootDir": "./src",
+    // Allow dynamic imports.
+    "module": "esnext",
     // Target latest version of ECMAScript.
     "target": "esnext",
     // Search under node_modules for non-relative imports.

--- a/packages/caravan-wallets/tsup.config.ts
+++ b/packages/caravan-wallets/tsup.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
       globals: { process: false },
     }),
   ],
+  external: ['bitbox-api'],
 });


### PR DESCRIPTION
Using the `bitbox-api` NPM package, which loads a WASM module.

Note about CJS:
Currently the `bitbox-api` package is an ESM package with a `module: ...` entrypoint, so it is not compatible with the `cjs` target of caravan-wallets. The only workaround that I could find where compilation succeeds and the package works in the browser is to mark bitbox-api as external in tsup.config.ts.

Note about signing tests:

- The BitBox02 requires the previous transaction of each input to be
present in the PSBT (`PSBT_IN_NON_WITNESS_UTXO`), so it can verify the
input amount and avoid fee attacks. The signing test fixtures are
missing these, so they fail.

- The BitBox02 uses the anti-klepto (anti-exfil) protocol to mitigate
covert nonce exfil attacks. This results in random signatures. The
unit test fixtures hardcode the expected signatures, assuming they are
always the same. As a result, also here the tests fail. To fix this,
the tests should rather verify the ECDSA signatures against the
transaction sighash for each input.
