### PR TITLE
fix: multisig support for indirect keystore interactions

### DIFF
--- a/.changeset/thirty-dolls-type.md
+++ b/.changeset/thirty-dolls-type.md
@@ -1,0 +1,5 @@
+---
+"@caravan/psbt": patch
+---
+
+Restore multisig support for indirect keystore interactions

--- a/packages/caravan-psbt/src/psbtv0/utils.ts
+++ b/packages/caravan-psbt/src/psbtv0/utils.ts
@@ -93,6 +93,12 @@ export interface LegacyMultisig {
     path: string;
     pubkey: Buffer;
   }[];
+  redeem?: {
+    output: Buffer;
+  };
+  witness?: {
+    output: Buffer;
+  };
 }
 
 // This may be incomplete as the fixture objects are extremely opaque.
@@ -137,8 +143,8 @@ export const convertLegacyOutput = (output: LegacyOutput): PsbtOutput => {
     value: new BigNumber(output.amountSats).toNumber(),
     bip32Derivation:
       output.bip32Derivation || getBip32Derivation(output.multisig),
-    witnessScript: output.witnessScript,
-    redeemScript: output.redeemScript,
+    witnessScript: output.witnessScript || output.multisig?.witness?.output,
+    redeemScript: output.redeemScript || output.multisig?.redeem?.output,
   };
 };
 


### PR DESCRIPTION
Fixes a regression in which PSBTs could not be signed in indirect keystore interactions due to a missing redeem script. 

[Introduced](https://github.com/caravan-bitcoin/caravan/commit/0d81717fade918ec337093e3dc4c3862662d20c3#diff-12369fc70a2ad8c599734fefe86246c867a701f3b5bda04eb964e56b822c2a25R137) in #91