### PR TITLE
unsignedPsbt in redux store should include global xpubs

### DIFF
--- a/apps/coordinator/src/reducers/transactionReducer.js
+++ b/apps/coordinator/src/reducers/transactionReducer.js
@@ -289,6 +289,7 @@ function finalizeOutputs(state, action) {
       network: state.network,
       inputs: state.inputs.map(convertLegacyInput),
       outputs: state.outputs.map(convertLegacyOutput),
+      includeGlobalXpubs: true,
     };
     const psbt = getUnsignedMultisigPsbtV0(args);
     unsignedTransaction = Transaction.fromHex(


### PR DESCRIPTION
We were storing the psbt in the state so that interactions could use if available (which was the right thing to do) but we were saving a version of the psbt without the global xpubs which is the wrong thing to do since some signers need this info. 