### PR TITLE
fix(wallets): bundle internal dependencies with production bundle

### DIFF
--- a/.changeset/thick-clouds-run.md
+++ b/.changeset/thick-clouds-run.md
@@ -1,0 +1,5 @@
+---
+"@caravan/wallets": patch
+---
+
+fix bundling of internal dependencies

--- a/packages/caravan-wallets/tsup.config.ts
+++ b/packages/caravan-wallets/tsup.config.ts
@@ -7,5 +7,9 @@ export default defineConfig({
       globals: { process: false },
     }),
   ],
-  external: ['bitbox-api'],
+  // make sure that the bitbox-api package is not bundled
+  external: ["bitbox-api"],
+  // noExternal makes sure that certain packages are bundled
+  // in the final package rather than independently installed
+  noExternal: ["@caravan/psbt", "@caravan/bitcoin"],
 });


### PR DESCRIPTION
When attempting to use caravan/wallets in an external application to leverage the fix that went out with #147 I was finding that the older external dependency was being used. 

There were two options I could come up with to resolve this. One was to pin the version for internal dependencies in the caravan/wallets package.json. This felt like it lost many of the benefits of working in a monorepo environment. The other was to bundle the internal dependency with the final production bundle. Since we bundle with tsup, we can use the noExternal config to take care of this.

Long term this feels like the cleaner pattern and we'll probably want to do this across the packages that we publish. 