### PR TITLE
fix: unknown network error for regtest

### DIFF
--- a/.changeset/stupid-starfishes-taste.md
+++ b/.changeset/stupid-starfishes-taste.md
@@ -1,0 +1,5 @@
+---
+"@caravan/wallets": patch
+---
+
+support regtest network in coldcard and custom interactions

--- a/packages/caravan-wallets/src/coldcard.ts
+++ b/packages/caravan-wallets/src/coldcard.ts
@@ -75,7 +75,11 @@ class ColdcardMultisigSettingsFileParser extends ColdcardInteraction {
     bip32Path: string;
   }) {
     super();
-    if ([Network.MAINNET, Network.TESTNET].find((net) => net === network)) {
+    if (
+      [Network.MAINNET, Network.TESTNET, Network.REGTEST].find(
+        (net) => net === network
+      )
+    ) {
       this.network = network;
     } else {
       throw new Error("Unknown network.");

--- a/packages/caravan-wallets/src/custom.ts
+++ b/packages/caravan-wallets/src/custom.ts
@@ -68,7 +68,11 @@ export class CustomExportExtendedPublicKey extends CustomInteraction {
 
   constructor({ network, bip32Path }) {
     super();
-    if ([Network.MAINNET, Network.TESTNET].find((net) => net === network)) {
+    if (
+      [Network.MAINNET, Network.TESTNET, Network.REGTEST].find(
+        (net) => net === network
+      )
+    ) {
       this.network = network;
     } else {
       throw new Error("Unknown network.");


### PR DESCRIPTION
Checks for REGTEST network in Coldcard and Custom interactions rather than throwing "Unknown network" 