### PR TITLE
fix: turbo dev depends on build w/ esbuild noExternal

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,9 @@
       "persistent": true
     },
     "dev": {
+     "dependsOn": [
+        "^build"
+      ],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
I noticed that after making the change in https://github.com/caravan-bitcoin/caravan/commit/5c3c456d78e8ab017cb960027d316cff98dc3ca2 turbo.json needed to define build as a dependency for dev tasks since the `noExternal` dep would need to be pre-built and bundled. I noticed this was breaking when trying to run `npm run dev` fresh. 