### PR TITLE
chore: update package-lock to match package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27524,7 +27524,7 @@
         "@ledgerhq/hw-transport-u2f": "^5.34.0",
         "@ledgerhq/hw-transport-webusb": "6.27.12",
         "@trezor/connect-web": "9.4.7",
-        "axios": "1.6.7",
+        "axios": "1.7.4",
         "bignumber.js": "^8.1.1",
         "bitbox-api": "^0.7.0",
         "bitcoinjs-lib": "^5.1.10",
@@ -30041,6 +30041,17 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "packages/caravan-wallets/node_modules/axios": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "packages/caravan-wallets/node_modules/base-x": {
       "version": "5.0.0",


### PR DESCRIPTION
The package-lock got out of sync from a dependabot merge.