### PR TITLE
fix: replace npm install with npm ci in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run tests
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       # the deploy action can't find the build directory if it's in the
       # sub directory of the monorepo, even if we reference it correctly


### PR DESCRIPTION
The use of `npm install` over `npm ci` allowed package-lock.json problems to be missed in the PR build. 
- [Release #133](https://github.com/caravan-bitcoin/caravan/actions/runs/12788151852)
- [Release #134](https://github.com/caravan-bitcoin/caravan/actions/runs/12938217541) 
