### PR TITLE
chore(turbo): add build as lint task dependency

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,11 @@
         "build/**"
       ]
     },
-    "lint": {},
+    "lint": {
+      "dependsOn": [
+        "^build"
+      ]
+    },
     "test": {
       "dependsOn": [
         "^build",


### PR DESCRIPTION
This resolved the error thrown when running `npm ci && npm run version`, as is run during the release action.

Error:
```
│ /GitHub/caravan/apps/coordinator/src/actions/keystoreActions.ts
│   1:58  error  Unable to resolve path to module '@caravan/wallets'  import/no-unresolved
│ 
│ /GitHub/caravan/apps/coordinator/src/components/Coldcard/ColdcardExtendedPublicKeyImpor
│ ter.jsx
│   3:26  error  Unable to resolve path to module '@caravan/wallets'  import/no-unresolved
```