### PR TITLE
Allow a PsbtV2 to be constructed with a psbtv2 which has been forceably set to have PSBT_GLOBAL_TX_VERSION === 1

### DIFF
--- a/.changeset/nice-cherries-remain.md
+++ b/.changeset/nice-cherries-remain.md
@@ -1,0 +1,5 @@
+---
+"@caravan/psbt": minor
+---
+
+allowTxnVersion1 option added to PsbtV2 constructor.

--- a/packages/caravan-psbt/src/psbtv2/psbtv2.test.ts
+++ b/packages/caravan-psbt/src/psbtv2/psbtv2.test.ts
@@ -866,6 +866,18 @@ describe("PsbtV2", () => {
     },
   );
 
+  test.each(BIP_174_VECTORS_VALID_PSBT)(
+    "Can instantiate from a serialized psbtv2 which has had its transaction version forceably set to 1. $case",
+    (vect) => {
+      const psbt = PsbtV2.FromV0(vect.base64, true);
+      const serialized = psbt.serialize();
+      expect(() => new PsbtV2(serialized, true)).not.toThrow();
+      if (psbt.PSBT_GLOBAL_TX_VERSION === 1) {
+        expect(() => new PsbtV2(serialized)).toThrow();
+      }
+    },
+  );
+
   it("Returns all PSBTv2 specific fields", () => {
     // Required fields are validated by the instance test. Here, just check
     // optionals.


### PR DESCRIPTION
This change is to help with compatibility when converting between psbt versions. `PsbtV2.FromV0()` has an option to create a PSBTv2 forceably setting the `PSBT_GLOBAL_TX_VERSION` field to 1. This is a bip370 non-compliant psbtv2, but it was presumably added for compatibility reasons when converting from v0.

A `PsbtV2` class created in such a way can be serialized with `PsbtV2.serialize()`, however, the resultant serialized psbt cannot be used to re-instantiate a `PsbtV2`. This change relaxes the Txnv2 requirement so that these exception case serialized psbts can be passed back into the constructor.

It should be carefully noted that this change might imply a dangerous use for a PSBTv2. The bip370 specifies that the txn v2 requirement was added to simplify the negotiation of validation rules for `OP_CHECKSEQUENCEVERIFY`. Forcing the txnv1 does not guarantee that consumers of the resultant psbtv2 will treat the calculated locktimes properly.