### PR TITLE
fix: fixed the private node rpc calls bug in clients `getTransaction` method

### DIFF
--- a/.changeset/proud-lemons-taste.md
+++ b/.changeset/proud-lemons-taste.md
@@ -1,0 +1,5 @@
+---
+"@caravan/clients": patch
+---
+
+fix: Private node transaction RPC call by aligning client.getTransaction method implementation with bitcoindRawTxData response

--- a/packages/caravan-clients/src/client.test.ts
+++ b/packages/caravan-clients/src/client.test.ts
@@ -1256,9 +1256,7 @@ describe("BlockchainClient", () => {
             bitcoind,
             "bitcoindRawTxData",
           );
-          mockBitcoindRawTxData.mockResolvedValue({
-            result: mockRawTransactionData,
-          });
+          mockBitcoindRawTxData.mockResolvedValue(mockRawTransactionData);
 
           const result = await client.getTransaction(mockTxid);
 

--- a/packages/caravan-clients/src/client.ts
+++ b/packages/caravan-clients/src/client.ts
@@ -517,7 +517,7 @@ export class BlockchainClient extends ClientBase {
           auth: this.bitcoindParams.auth,
           txid,
         });
-        txData = response.result;
+        txData = response;
       } else if (
         this.type === ClientType.BLOCKSTREAM ||
         this.type === ClientType.MEMPOOL


### PR DESCRIPTION
### Issue Context: Bug in `BlockchainClient.getTransaction` (#134)

As discussed in [this comment](https://github.com/caravan-bitcoin/caravan/pull/168#issuecomment-2725787590), there appears to be a bug in the `BlockchainClient.getTransaction` method. The issue arises because the method does not correctly access the `result` property, which is already being returned by `bitcoindRawTxData`.

This oversight leads to unexpected behavior in the live clients package, as the transaction data is not properly retrieved or processed.
---

### Proposed Fix

The patch aims to resolve this issue by ensuring that the `result` property is correctly accessed and utilized within the `getTransaction` method. This adjustment will align the implementation with the expected behavior and improve the reliability of the live clients package.

---

cc: @bucko13 