### PR TITLE
Remove requirement of PSBT_GLOBAL_FALLBACK_LOCKTIME on PsbtV2.isReadyForConstructor

### DIFF
--- a/.changeset/eight-singers-smoke.md
+++ b/.changeset/eight-singers-smoke.md
@@ -1,0 +1,5 @@
+---
+"@caravan/psbt": minor
+---
+
+Fixes PsbtV2.isReadyForConstructor by not requiring that PSBT_GLOBAL_FALLBACK_LOCKTIME be set. This field is not required on a psbtv2 per BIP370.

--- a/packages/caravan-psbt/src/psbtv2/psbtv2.test.ts
+++ b/packages/caravan-psbt/src/psbtv2/psbtv2.test.ts
@@ -913,11 +913,6 @@ describe("PsbtV2.isReadyForConstructor", () => {
     psbt = new PsbtV2();
   });
 
-  it("Returns not ready for Constructor when PSBT_GLOBAL_FALLBACK_LOCKTIME is not set", () => {
-    psbt.PSBT_GLOBAL_FALLBACK_LOCKTIME = null;
-    expect(psbt.isReadyForConstructor).toBe(false);
-  });
-
   it("Returns not ready for Constructor when neither inputs or outputs are modifiable", () => {
     psbt.PSBT_GLOBAL_TX_MODIFIABLE = [];
     expect(psbt.isReadyForConstructor).toBe(false);

--- a/packages/caravan-psbt/src/psbtv2/psbtv2.ts
+++ b/packages/caravan-psbt/src/psbtv2/psbtv2.ts
@@ -490,13 +490,6 @@ export class PsbtV2 extends PsbtV2Maps {
    * set).
    */
   get isReadyForConstructor() {
-    // The Creator role (likely via the class constructor) must ensure at least
-    // the following value has been initialized. The psbt cannot be passed to
-    // the Constructor until it is set.
-    if (this.PSBT_GLOBAL_FALLBACK_LOCKTIME === null) {
-      return false;
-    }
-
     // At least inputs or outputs must still be modifiable.
     if (
       !this.isModifiable([PsbtGlobalTxModifiableBits.INPUTS]) &&


### PR DESCRIPTION
According to BIP370, the Creator role can set `PSBT_GLOBAL_FALLBACK_LOCKTIME`, but it is not a required key on a psbtv2. If it doesn't exist, it is assumed to be 0. This key shouldn't be part of the check for `isReadyForConstructor`.