### PR TITLE
Feat/add get wallet transaction

### DIFF
--- a/.changeset/fresh-wolves-tickle.md
+++ b/.changeset/fresh-wolves-tickle.md
@@ -1,0 +1,5 @@
+---
+"@caravan/clients": minor
+---
+
+Add a new method `getWalletTransaction` in BlockchainClient and `bitcoindGetWalletTransaction` in wallet methods

--- a/packages/caravan-clients/src/client.test.ts
+++ b/packages/caravan-clients/src/client.test.ts
@@ -1422,6 +1422,7 @@ describe("BlockchainClient", () => {
         version: 2,
         locktime: 0,
         size: 225,
+        vsize: 225,
         weight: 900,
         fee: 25000, // Converted from -0.00025 BTC to 25000 sats and made positive
         vin: [
@@ -1511,6 +1512,203 @@ describe("BlockchainClient", () => {
 
       // Fee should be 0 when missing
       expect(result.fee).toBe(0);
+    });
+  });
+
+  describe("getWalletTransaction", () => {
+    let mockGetWalletTransaction: jest.SpyInstance;
+
+    beforeEach(() => {
+      mockGetWalletTransaction = jest.spyOn(
+        wallet,
+        "bitcoindGetWalletTransaction",
+      );
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("should throw error for non-private clients", async () => {
+      const blockstreamClient = new BlockchainClient({
+        type: ClientType.BLOCKSTREAM,
+        network: Network.MAINNET,
+      });
+
+      await expect(
+        blockstreamClient.getWalletTransaction("txid123"),
+      ).rejects.toThrow(
+        "Wallet transactions are only available for private Bitcoin nodes",
+      );
+
+      const mempoolClient = new BlockchainClient({
+        type: ClientType.MEMPOOL,
+        network: Network.MAINNET,
+      });
+
+      await expect(
+        mempoolClient.getWalletTransaction("txid123"),
+      ).rejects.toThrow(
+        "Wallet transactions are only available for private Bitcoin nodes",
+      );
+    });
+
+    it("should throw error when wallet name is missing", async () => {
+      const client = new BlockchainClient({
+        type: ClientType.PRIVATE,
+        network: Network.MAINNET,
+        client: {
+          url: "http://localhost:8332",
+          username: "user",
+          password: "pass",
+          // No walletName provided
+        },
+      });
+
+      await expect(client.getWalletTransaction("txid123")).rejects.toThrow(
+        "Wallet name is required for wallet transaction lookups",
+      );
+    });
+
+    it("should retrieve and transform wallet transaction data", async () => {
+      // Sample wallet transaction response
+      const mockWalletTxData: WalletTransactionResponse = {
+        amount: -1.5,
+        fee: -0.00025,
+        confirmations: 6,
+        blockhash:
+          "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+        blockheight: 123456,
+        blocktime: 1631234567,
+        txid: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        hex: "01000000...",
+        walletconflicts: [],
+        time: 1631234560,
+        details: [
+          {
+            address: "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+            category: "send",
+            amount: -1.5,
+            vout: 0,
+            fee: -0.0025,
+            abandoned: false,
+          },
+        ],
+        timereceived: 1631234562,
+        "bip125-replaceable": "no",
+        decoded: {
+          txid: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          hash: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          version: 2,
+          size: 225,
+          vsize: 225,
+          weight: 900,
+          locktime: 0,
+          vin: [
+            {
+              txid: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+              vout: 1,
+              scriptSig: { asm: "", hex: "" },
+              sequence: 4294967295,
+            },
+          ],
+          vout: [
+            {
+              value: 1.4997,
+              n: 0,
+              scriptPubKey: {
+                asm: "OP_DUP OP_HASH160 ...",
+                hex: "76a914...",
+                type: "pubkeyhash",
+                address: "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+              },
+            },
+          ],
+        },
+      };
+
+      // Expected normalized data
+      const expectedTransactionDetails = {
+        txid: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        version: 2,
+        locktime: 0,
+        vin: [
+          {
+            txid: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            vout: 1,
+            sequence: 4294967295,
+          },
+        ],
+        vout: [
+          {
+            value: 1.4997,
+            scriptPubkey: "76a914...",
+            scriptPubkeyAddress: "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+          },
+        ],
+        size: 225,
+        vsize: 225,
+        weight: 900,
+        fee: 25000, // Fee is in satoshis for PRIVATE client
+        status: {
+          confirmed: true,
+          blockHeight: 123456,
+          blockHash:
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+          blockTime: 1631234567,
+        },
+      };
+
+      mockGetWalletTransaction.mockResolvedValue(mockWalletTxData);
+
+      const client = new BlockchainClient({
+        type: ClientType.PRIVATE,
+        network: Network.MAINNET,
+        client: {
+          url: "http://localhost:8332",
+          username: "user",
+          password: "pass",
+          walletName: "wallet",
+        },
+      });
+
+      const result = await client.getWalletTransaction("txid123");
+
+      expect(mockGetWalletTransaction).toHaveBeenCalledWith({
+        url: client.bitcoindParams.url,
+        auth: client.bitcoindParams.auth,
+        walletName: client.bitcoindParams.walletName,
+        txid: "txid123",
+      });
+
+      expect(result).toEqual(expectedTransactionDetails);
+    });
+
+    it("should handle errors from bitcoindGetWalletTransaction", async () => {
+      const mockError = new Error("Transaction not found in wallet");
+      mockGetWalletTransaction.mockRejectedValue(mockError);
+
+      const client = new BlockchainClient({
+        type: ClientType.PRIVATE,
+        network: Network.MAINNET,
+        client: {
+          url: "http://localhost:8332",
+          username: "user",
+          password: "pass",
+          walletName: "wallet",
+        },
+      });
+
+      await expect(client.getWalletTransaction("txid123")).rejects.toThrow(
+        `Failed to get wallet transaction: ${mockError.message}`,
+      );
+
+      expect(mockGetWalletTransaction).toHaveBeenCalledWith({
+        url: client.bitcoindParams.url,
+        auth: client.bitcoindParams.auth,
+        walletName: client.bitcoindParams.walletName,
+        txid: "txid123",
+      });
     });
   });
 });

--- a/packages/caravan-clients/src/client.test.ts
+++ b/packages/caravan-clients/src/client.test.ts
@@ -4,11 +4,17 @@ import {
   ClientType,
   ClientBase,
   BlockchainClientError,
+  transformWalletTransactionToRawTransactionData,
 } from "./client";
 import * as bitcoind from "./bitcoind";
 import * as wallet from "./wallet";
 import BigNumber from "bignumber.js";
-import { UTXO, RawTransactionData, TransactionDetails } from "./types";
+import {
+  UTXO,
+  RawTransactionData,
+  TransactionDetails,
+  WalletTransactionResponse,
+} from "./types";
 import axios from "axios";
 jest.mock("axios");
 
@@ -1350,6 +1356,161 @@ describe("BlockchainClient", () => {
           `Failed to get transaction: ${mockError.message}`,
         );
       });
+    });
+  });
+  describe("transformWalletTransactionToRawTransactionData", () => {
+    it("should correctly transform wallet transaction to raw transaction data", () => {
+      const walletTx: WalletTransactionResponse = {
+        amount: -1.5,
+        fee: -0.00025,
+        confirmations: 6,
+        blockhash:
+          "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+        blockheight: 123456,
+        blocktime: 1631234567,
+        txid: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        hex: "01000000...",
+        walletconflicts: [],
+        time: 1631234560,
+        details: [
+          {
+            address: "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+            category: "send",
+            amount: -1.5,
+            vout: 0,
+            fee: -0.0025,
+            abandoned: false,
+          },
+        ],
+        timereceived: 1631234562,
+        "bip125-replaceable": "no",
+        decoded: {
+          txid: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          hash: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          version: 2,
+          size: 225,
+          vsize: 225,
+          weight: 900,
+          locktime: 0,
+          vin: [
+            {
+              txid: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+              vout: 1,
+              scriptSig: { asm: "", hex: "" },
+              sequence: 4294967295,
+            },
+          ],
+          vout: [
+            {
+              value: 1.4997,
+              n: 0,
+              scriptPubKey: {
+                asm: "OP_DUP OP_HASH160 ...",
+                hex: "76a914...",
+                type: "pubkeyhash",
+                address: "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+              },
+            },
+          ],
+        },
+      };
+
+      const result = transformWalletTransactionToRawTransactionData(walletTx);
+
+      expect(result).toEqual({
+        txid: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        version: 2,
+        locktime: 0,
+        size: 225,
+        weight: 900,
+        fee: 25000, // Converted from -0.00025 BTC to 25000 sats and made positive
+        vin: [
+          {
+            txid: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            vout: 1,
+            sequence: 4294967295,
+          },
+        ],
+        vout: [
+          {
+            value: 1.4997,
+            scriptpubkey: "76a914...",
+            scriptpubkey_address: "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+          },
+        ],
+        confirmations: 6,
+        blockhash:
+          "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+        blocktime: 1631234567,
+        status: {
+          confirmed: true,
+          block_height: 123456,
+          block_hash:
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+          block_time: 1631234567,
+        },
+        hex: "01000000...",
+      });
+    });
+
+    it("should throw an error when decoded data is missing", () => {
+      const walletTx = {
+        amount: -1.5,
+        fee: -0.00025,
+        confirmations: 6,
+        blockhash:
+          "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+        txid: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        // No decoded field
+      };
+
+      expect(() =>
+        transformWalletTransactionToRawTransactionData(walletTx as any),
+      ).toThrow("Transaction decoded data is missing");
+    });
+
+    it("should handle missing fee value", () => {
+      const walletTx = {
+        amount: -1.5,
+        // No fee field
+        confirmations: 6,
+        blockhash:
+          "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+        blockheight: 123456,
+        blocktime: 1631234567,
+        txid: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        decoded: {
+          txid: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          version: 2,
+          size: 225,
+          weight: 900,
+          locktime: 0,
+          vin: [
+            {
+              txid: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+              vout: 1,
+              sequence: 4294967295,
+            },
+          ],
+          vout: [
+            {
+              value: 1.4997,
+              n: 0,
+              scriptPubKey: {
+                hex: "76a914...",
+                addresses: ["1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"],
+              },
+            },
+          ],
+        },
+      };
+
+      const result = transformWalletTransactionToRawTransactionData(
+        walletTx as any,
+      );
+
+      // Fee should be 0 when missing
+      expect(result.fee).toBe(0);
     });
   });
 });

--- a/packages/caravan-clients/src/client.ts
+++ b/packages/caravan-clients/src/client.ts
@@ -594,7 +594,6 @@ export class BlockchainClient extends ClientBase {
         txid,
       });
 
-      // Transform the wallet transaction format to the standard format using our helper function
       const normalizedTxData: RawTransactionData =
         transformWalletTransactionToRawTransactionData(walletTxData);
 

--- a/packages/caravan-clients/src/client.ts
+++ b/packages/caravan-clients/src/client.ts
@@ -74,6 +74,7 @@ export function transformWalletTransactionToRawTransactionData(
     version: walletTx.decoded.version,
     locktime: walletTx.decoded.locktime,
     size: walletTx.decoded.size,
+    vsize: walletTx.decoded.vsize,
     weight: walletTx.decoded.weight,
     fee: feeSats, // Convert from BTC to satoshis
     vin: walletTx.decoded.vin.map((input) => ({
@@ -129,6 +130,8 @@ export function normalizeTransactionData(
       scriptPubkeyAddress: output.scriptpubkey_address,
     })),
     size: txData.size,
+    // add the vsize property to the returned object if txData.vsize is defined
+    ...(txData.vsize !== undefined && { vsize: txData.vsize }),
     weight: txData.weight,
     fee: clientType === ClientType.PRIVATE ? txData.fee || 0 : txData.fee,
     status: {

--- a/packages/caravan-clients/src/types.ts
+++ b/packages/caravan-clients/src/types.ts
@@ -315,3 +315,61 @@ export interface UTXOUpdates {
   fetchUTXOsError: string;
   addressKnown?: boolean;
 }
+
+/**
+ * Interface for Bitcoin wallet transaction response
+ * @see https://developer.bitcoin.org/reference/rpc/gettransaction.html
+ */
+export interface WalletTransactionResponse {
+  in_active_chain?: boolean; // Whether specified block is in the active chain
+  hex: string; // The serialized, hex-encoded data
+  txid: string; // The transaction id
+  hash: string; // The transaction hash (differs from txid for witness transactions)
+  size: number; // The serialized transaction size
+  vsize: number; // The virtual transaction size
+  weight: number; // The transaction's weight
+  version: number; // The version
+  locktime: number; // The lock time
+  vin: {
+    // Transaction inputs
+    txid: string; // The transaction id
+    vout: number; // The output number
+    scriptSig: {
+      // The script
+      asm: string; // asm
+      hex: string; // hex
+    };
+    sequence: number; // The script sequence number
+    txinwitness?: string[]; // hex-encoded witness data (if any)
+  }[];
+  vout: {
+    // Transaction outputs
+    value: number; // The value in BTC
+    n: number; // index
+    scriptPubKey: {
+      // Script info
+      asm: string; // the asm
+      hex: string; // the hex
+      reqSigs?: number; // The required sigs
+      type: string; // The type, eg 'pubkeyhash'
+      addresses?: string[]; // bitcoin addresses
+    };
+  }[];
+  blockhash?: string; // the block hash
+  confirmations: number; // The confirmations
+  blocktime?: number; // The block time expressed in UNIX epoch time
+  time: number; // Same as "blocktime" for confirmed tx, wallet entry time for unconfirmed
+  walletconflicts: string[]; // Conflicting transactions
+  fee?: number; // Transaction fee (negative for outgoing transactions)
+  details: {
+    // Details about each payment
+    address: string; // The bitcoin address
+    category: "send" | "receive" | "generate" | "immature" | "orphan";
+    amount: number; // The amount in BTC
+    label?: string; // A comment for the address/transaction
+    vout: number; // the vout value
+    fee?: number; // The amount of the fee in BTC
+    abandoned?: boolean; // Whether a transaction was abandoned
+  }[];
+  bip125_replaceable: "yes" | "no" | "unknown"; // Whether this transaction could be replaced
+}

--- a/packages/caravan-clients/src/types.ts
+++ b/packages/caravan-clients/src/types.ts
@@ -321,55 +321,69 @@ export interface UTXOUpdates {
  * @see https://developer.bitcoin.org/reference/rpc/gettransaction.html
  */
 export interface WalletTransactionResponse {
-  in_active_chain?: boolean; // Whether specified block is in the active chain
-  hex: string; // The serialized, hex-encoded data
-  txid: string; // The transaction id
-  hash: string; // The transaction hash (differs from txid for witness transactions)
-  size: number; // The serialized transaction size
-  vsize: number; // The virtual transaction size
-  weight: number; // The transaction's weight
-  version: number; // The version
-  locktime: number; // The lock time
-  vin: {
-    // Transaction inputs
-    txid: string; // The transaction id
-    vout: number; // The output number
-    scriptSig: {
-      // The script
-      asm: string; // asm
-      hex: string; // hex
-    };
-    sequence: number; // The script sequence number
-    txinwitness?: string[]; // hex-encoded witness data (if any)
-  }[];
-  vout: {
-    // Transaction outputs
-    value: number; // The value in BTC
-    n: number; // index
-    scriptPubKey: {
-      // Script info
-      asm: string; // the asm
-      hex: string; // the hex
-      reqSigs?: number; // The required sigs
-      type: string; // The type, eg 'pubkeyhash'
-      addresses?: string[]; // bitcoin addresses
-    };
-  }[];
-  blockhash?: string; // the block hash
-  confirmations: number; // The confirmations
-  blocktime?: number; // The block time expressed in UNIX epoch time
-  time: number; // Same as "blocktime" for confirmed tx, wallet entry time for unconfirmed
-  walletconflicts: string[]; // Conflicting transactions
-  fee?: number; // Transaction fee (negative for outgoing transactions)
+  amount: number; // The total amount (negative for outgoing transactions)
+  fee: number; // The fee amount (negative for outgoing transactions)
+  confirmations: number; // Number of confirmations
+  blockhash?: string; // The block hash containing the transaction
+  blockheight?: number; // The block height containing the transaction
+  blockindex?: number; // Position of tx in the block
+  blocktime?: number; // Block time in UNIX epoch time
+  txid: string; // The transaction ID
+  wtxid?: string; // The witness transaction ID
+  walletconflicts: string[]; // Conflicting transaction IDs
+  mempoolconflicts?: string[]; // Conflicts in mempool
+  time: number; // Transaction time in UNIX epoch time
+  timereceived: number; // Time received in UNIX epoch time
+  "bip125-replaceable": "yes" | "no" | "unknown"; // Replace-by-fee status
+
   details: {
-    // Details about each payment
-    address: string; // The bitcoin address
+    address: string;
     category: "send" | "receive" | "generate" | "immature" | "orphan";
-    amount: number; // The amount in BTC
-    label?: string; // A comment for the address/transaction
-    vout: number; // the vout value
-    fee?: number; // The amount of the fee in BTC
-    abandoned?: boolean; // Whether a transaction was abandoned
+    amount: number; // Amount (negative for outgoing)
+    vout: number; // Output index
+    fee?: number; // Fee amount (if category is "send")
+    abandoned?: boolean; // If the transaction was abandoned
+    label?: string; // Address label if any
   }[];
-  bip125_replaceable: "yes" | "no" | "unknown"; // Whether this transaction could be replaced
+
+  hex: string; // Raw transaction data
+
+  decoded?: {
+    // Only present when verbose=true
+    txid: string;
+    hash: string; // Witness transaction hash
+    version: number;
+    size: number; // Transaction size in bytes
+    vsize: number; // Virtual size (for segwit)
+    weight: number; // Transaction weight
+    locktime: number;
+
+    vin: {
+      txid: string; // Input transaction ID
+      vout: number; // Referenced output
+      scriptSig: {
+        asm: string;
+        hex: string;
+      };
+      txinwitness?: string[]; // Witness data (for segwit inputs)
+      sequence: number;
+    }[];
+
+    vout: {
+      value: number; // Output amount in BTC
+      n: number; // Output index
+      scriptPubKey: {
+        asm: string;
+        desc?: string; // Output descriptor
+        hex: string;
+        address?: string; // Bitcoin address
+        type: string; // Script type
+      };
+    }[];
+  };
+  lastprocessedblock?: {
+    // Information about the last processed block
+    hash: string;
+    height: number;
+  };
 }

--- a/packages/caravan-clients/src/types.ts
+++ b/packages/caravan-clients/src/types.ts
@@ -84,6 +84,7 @@ export interface RawTransactionData {
   vin: RawTxInput[];
   vout: RawTxOutput[];
   size: number;
+  vsize?: number;
   weight: number;
   fee: number;
   status?: RawTxStatus; // Optional for private node
@@ -109,6 +110,7 @@ export interface TransactionDetails {
     scriptPubkeyAddress?: string;
   }>;
   size: number;
+  vsize?: number;
   weight: number;
   fee: number;
   status: {

--- a/packages/caravan-clients/src/wallet.test.ts
+++ b/packages/caravan-clients/src/wallet.test.ts
@@ -4,9 +4,11 @@ import {
   bitcoindImportDescriptors,
   bitcoindGetAddressStatus,
   bitcoindListUnspent,
+  bitcoindGetWalletTransaction,
 } from "./wallet";
 
 import * as bitcoind from "./bitcoind";
+import { WalletTransactionResponse } from "./types";
 import BigNumber from "bignumber.js";
 
 describe("Wallet Functions", () => {
@@ -260,6 +262,151 @@ describe("Wallet Functions", () => {
           time: getTransactionResponse.blocktime,
         },
       ]);
+    });
+  });
+
+  describe("bitcoindGetWalletTransaction", () => {
+    const txid =
+      "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+    const includeWatchonly = true;
+    const verbose = true;
+
+    it("should call callBitcoindWallet with gettransaction and correct parameters", async () => {
+      // Sample response based on Bitcoin Core's gettransaction RPC
+      const mockResponse = {
+        result: {
+          amount: -0.12345678,
+          fee: -0.0001,
+          confirmations: 6,
+          blockhash:
+            "000000000000000000000000000000000000000000000000000000000000000a",
+          blockheight: 680000,
+          blockindex: 1,
+          blocktime: 1631234567,
+          txid,
+          walletconflicts: [],
+          time: 1631234560,
+          timereceived: 1631234562,
+          "bip125-replaceable": "no",
+          details: [
+            {
+              address: "bc1qxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+              category: "send",
+              amount: -0.12345678,
+              vout: 0,
+              fee: -0.0001,
+              abandoned: false,
+            },
+          ],
+          hex: "0200000000010100000000000000000000000000000000000000000000000000000000000000000000000000ffffffff01000000000000000000160014000000000000000000000000000000000000000000000000",
+          decoded: {
+            txid,
+            hash: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            version: 2,
+            size: 110,
+            vsize: 110,
+            weight: 440,
+            locktime: 0,
+            vin: [
+              {
+                txid: "0000000000000000000000000000000000000000000000000000000000000000",
+                vout: 0,
+                scriptSig: {
+                  asm: "",
+                  hex: "",
+                },
+                sequence: 4294967295,
+              },
+            ],
+            vout: [
+              {
+                value: 0.12345678,
+                n: 0,
+                scriptPubKey: {
+                  asm: "0 0000000000000000000000000000000000000000",
+                  hex: "00140000000000000000000000000000000000000000",
+                  type: "witness_v0_keyhash",
+                  address: "bc1qxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                },
+              },
+            ],
+          },
+        } as WalletTransactionResponse,
+      };
+
+      mockCallBitcoind.mockResolvedValue(mockResponse);
+
+      const result = await bitcoindGetWalletTransaction({
+        url: baseUrl,
+        auth,
+        walletName,
+        txid,
+        includeWatchonly,
+        verbose,
+      });
+
+      expect(mockCallBitcoind).toHaveBeenCalledWith(
+        expectedWalletPath,
+        auth,
+        "gettransaction",
+        [txid, includeWatchonly, verbose],
+      );
+
+      expect(result).toEqual(mockResponse.result);
+    });
+
+    it("should throw error if result is undefined", async () => {
+      mockCallBitcoind.mockResolvedValue({ result: undefined });
+
+      await expect(
+        bitcoindGetWalletTransaction({
+          url: baseUrl,
+          auth,
+          walletName,
+          txid,
+        }),
+      ).rejects.toThrow(
+        `Error: invalid response from ${baseUrl} for transaction ${txid}`,
+      );
+    });
+
+    it("should use correct defaults for optional parameters", async () => {
+      mockCallBitcoind.mockResolvedValue({ result: {} });
+
+      await bitcoindGetWalletTransaction({
+        url: baseUrl,
+        auth,
+        walletName,
+        txid,
+      });
+
+      // Default values: includeWatchonly=true, verbose=true
+      expect(mockCallBitcoind).toHaveBeenCalledWith(
+        expectedWalletPath,
+        auth,
+        "gettransaction",
+        [txid, true, true],
+      );
+    });
+
+    it("should accept custom values for optional parameters", async () => {
+      mockCallBitcoind.mockResolvedValue({ result: {} });
+
+      await bitcoindGetWalletTransaction({
+        url: baseUrl,
+        auth,
+        walletName,
+        txid,
+        includeWatchonly: false,
+        verbose: false,
+      });
+
+      expect(mockCallBitcoind).toHaveBeenCalledWith(
+        expectedWalletPath,
+        auth,
+        "gettransaction",
+        [txid, false, false],
+      );
     });
   });
 });

--- a/packages/caravan-clients/src/wallet.ts
+++ b/packages/caravan-clients/src/wallet.ts
@@ -216,3 +216,50 @@ export async function bitcoindListUnspent({
     throw e;
   }
 }
+
+/**
+ * Gets detailed information about a wallet transaction
+ *
+ * This function uses the "gettransaction" RPC call which includes fee information
+ * for wallet transactions, unlike getrawtransaction which requires txindex=1 and
+ * doesn't include fee data.
+ *
+ * @see https://developer.bitcoin.org/reference/rpc/gettransaction.html
+ *
+ * @param options - Connection details and transaction ID
+ * @returns Detailed transaction data with fee information
+ */
+export async function bitcoindGetWalletTransaction({
+  url,
+  auth,
+  walletName,
+  txid,
+  includeWatchonly = true,
+  verbose = true,
+}: BaseBitcoindParams & {
+  txid: string;
+  includeWatchonly?: boolean;
+  verbose?: boolean;
+}): Promise<any> {
+  try {
+    const response = await callBitcoindWallet({
+      baseUrl: url,
+      walletName,
+      auth,
+      method: "gettransaction",
+      params: [txid, includeWatchonly, verbose],
+    });
+
+    if (typeof response?.result === "undefined") {
+      throw new BitcoindWalletClientError(
+        `Error: invalid response from ${url} for transaction ${txid}`,
+      );
+    }
+
+    return response.result;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error("Error getting wallet transaction:", (e as Error).message);
+    throw e;
+  }
+}


### PR DESCRIPTION
# Add support for wallet transaction fee data in private nodes

## Problem
When using Caravan with a local regtest node (or any private node), transaction fees were not showing up in the UI. This is because the current implementation uses the `getrawtransaction` RPC call, which doesn't include fee information, rather than the wallet-specific `gettransaction` call.

## Solution
This PR adds a new method `getWalletTransaction` that uses the Bitcoin Core `gettransaction` RPC call to retrieve fee information for transactions tracked by the wallet. 

- Added `bitcoindGetWalletTransaction` function for direct RPC access
- Added `getWalletTransaction` method to the BlockchainClient class
- Added tests for above methods