### PR TITLE
[Test]: Jest to Vitest migration `multisig` package 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -590,6 +590,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
+      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==",
+      "license": "MIT"
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
       "license": "Apache-2.0",
@@ -3289,11 +3295,15 @@
       "license": "MIT"
     },
     "node_modules/@emurgo/cardano-serialization-lib-browser": {
-      "version": "11.5.0",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-browser/-/cardano-serialization-lib-browser-13.2.1.tgz",
+      "integrity": "sha512-7RfX1gI16Vj2DgCp/ZoXqyLAakWo6+X95ku/rYGbVzuS/1etrlSiJmdbmdm+eYmszMlGQjrtOJQeVLXoj4L/Ag==",
       "license": "MIT"
     },
     "node_modules/@emurgo/cardano-serialization-lib-nodejs": {
-      "version": "11.5.0",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-13.2.0.tgz",
+      "integrity": "sha512-Bz1zLGEqBQ0BVkqt1OgMxdBOE3BdUWUd7Ly9Ecr/aUwkA8AV1w1XzBMe4xblmJHnB1XXNlPH4SraXCvO+q0Mig==",
       "license": "MIT"
     },
     "node_modules/@esbuild/linux-x64": {
@@ -3421,6 +3431,8 @@
     },
     "node_modules/@ethereumjs/common": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-4.4.0.tgz",
+      "integrity": "sha512-Fy5hMqF6GsE6DpYTyqdDIJPJgUtDn4dL120zKw+Pswuo+iLyBsEYuSyzMw6NVzD2vDzcBG9fE4+qX4X2bPc97w==",
       "license": "MIT",
       "dependencies": {
         "@ethereumjs/util": "^9.1.0"
@@ -3428,6 +3440,8 @@
     },
     "node_modules/@ethereumjs/rlp": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
+      "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==",
       "license": "MPL-2.0",
       "bin": {
         "rlp": "bin/rlp.cjs"
@@ -3438,6 +3452,8 @@
     },
     "node_modules/@ethereumjs/tx": {
       "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-5.4.0.tgz",
+      "integrity": "sha512-SCHnK7m/AouZ7nyoR0MEXw1OO/tQojSbp88t8oxhwes5iZkZCtfFdUrJaiIb72qIpH2FVw6s1k1uP7LXuH7PsA==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/common": "^4.4.0",
@@ -3451,6 +3467,8 @@
     },
     "node_modules/@ethereumjs/util": {
       "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.1.0.tgz",
+      "integrity": "sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",
@@ -3458,6 +3476,791 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@ethersproject/abi": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.8.0.tgz",
+      "integrity": "sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-provider": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz",
+      "integrity": "sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/networks": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/web": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-signer": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz",
+      "integrity": "sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/address": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+      "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/base64": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.8.0.tgz",
+      "integrity": "sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/basex": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.8.0.tgz",
+      "integrity": "sha512-PIgTszMlDRmNwW9nhS6iqtVfdTAKosA7llYXNmGPw4YAI1PUyMv28988wAb41/gHF/WqGdoLv0erHaRcHRKW2Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/bignumber": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
+      "integrity": "sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "bn.js": "^5.2.1"
+      }
+    },
+    "node_modules/@ethersproject/bignumber/node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "license": "MIT"
+    },
+    "node_modules/@ethersproject/bytes": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.8.0.tgz",
+      "integrity": "sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/constants": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.8.0.tgz",
+      "integrity": "sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/contracts": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.8.0.tgz",
+      "integrity": "sha512-0eFjGz9GtuAi6MZwhb4uvUM216F38xiuR0yYCjKJpNfSEy4HUM8hvqqBj9Jmm0IUz8l0xKEhWwLIhPgxNY0yvQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abi": "^5.8.0",
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/hash": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
+      "integrity": "sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/hdnode": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.8.0.tgz",
+      "integrity": "sha512-4bK1VF6E83/3/Im0ERnnUeWOY3P1BZml4ZD3wcH8Ys0/d1h1xaFt6Zc+Dh9zXf9TapGro0T4wvO71UTCp3/uoA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/basex": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/pbkdf2": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/sha2": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/wordlists": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/json-wallets": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.8.0.tgz",
+      "integrity": "sha512-HxblNck8FVUtNxS3VTEYJAcwiKYsBIF77W15HufqlBF9gGfhmYOJtYZp8fSDZtn9y5EaXTE87zDwzxRoTFk11w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/hdnode": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/pbkdf2": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/random": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1"
+      }
+    },
+    "node_modules/@ethersproject/keccak256": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz",
+      "integrity": "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "js-sha3": "0.8.0"
+      }
+    },
+    "node_modules/@ethersproject/logger": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.8.0.tgz",
+      "integrity": "sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@ethersproject/networks": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.8.0.tgz",
+      "integrity": "sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/pbkdf2": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.8.0.tgz",
+      "integrity": "sha512-wuHiv97BrzCmfEaPbUFpMjlVg/IDkZThp9Ri88BpjRleg4iePJaj2SW8AIyE8cXn5V1tuAaMj6lzvsGJkGWskg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/sha2": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/properties": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
+      "integrity": "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/providers": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.8.0.tgz",
+      "integrity": "sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/basex": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/networks": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/random": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0",
+        "@ethersproject/sha2": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/web": "^5.8.0",
+        "bech32": "1.1.4",
+        "ws": "8.18.0"
+      }
+    },
+    "node_modules/@ethersproject/providers/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ethersproject/random": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.8.0.tgz",
+      "integrity": "sha512-E4I5TDl7SVqyg4/kkA/qTfuLWAQGXmSOgYyO01So8hLfwgKvYK5snIlzxJMk72IFdG/7oh8yuSqY2KX7MMwg+A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/rlp": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.8.0.tgz",
+      "integrity": "sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/sha2": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.8.0.tgz",
+      "integrity": "sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/signing-key": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.8.0.tgz",
+      "integrity": "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "bn.js": "^5.2.1",
+        "elliptic": "6.6.1",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/signing-key/node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "license": "MIT"
+    },
+    "node_modules/@ethersproject/solidity": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.8.0.tgz",
+      "integrity": "sha512-4CxFeCgmIWamOHwYN9d+QWGxye9qQLilpgTU0XhYs1OahkclF+ewO+3V1U0mvpiuQxm5EHHmv8f7ClVII8EHsA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/sha2": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/strings": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.8.0.tgz",
+      "integrity": "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/transactions": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.8.0.tgz",
+      "integrity": "sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/units": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.8.0.tgz",
+      "integrity": "sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/wallet": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.8.0.tgz",
+      "integrity": "sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/hdnode": "^5.8.0",
+        "@ethersproject/json-wallets": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/random": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/wordlists": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/web": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
+      "integrity": "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/wordlists": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.8.0.tgz",
+      "integrity": "sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@everstake/wallet-sdk": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@everstake/wallet-sdk/-/wallet-sdk-1.0.13.tgz",
+      "integrity": "sha512-ibzbHT86rXRWCmPtnJH5IcLAOtOZJOtwJqZDjpdYEkojhpreDrCTlTYh8j6B8oxZgjiHqBcXiQlo+QMCHthvIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@solana/web3.js": "1.95.8",
+        "bignumber.js": "9.1.2",
+        "ethereum-multicall": "^2.26.0",
+        "superstruct": "2.0.2",
+        "web3": "4.16.0"
+      }
+    },
+    "node_modules/@everstake/wallet-sdk/node_modules/@solana/web3.js": {
+      "version": "1.95.8",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.95.8.tgz",
+      "integrity": "sha512-sBHzNh7dHMrmNS5xPD1d0Xa2QffW/RXaxu/OysRXBfwTp+LYqGGmMtCYYwrHPrN5rjAmJCsQRNAwv4FM0t3B6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "@noble/curves": "^1.4.2",
+        "@noble/hashes": "^1.4.0",
+        "@solana/buffer-layout": "^4.0.1",
+        "agentkeepalive": "^4.5.0",
+        "bigint-buffer": "^1.1.5",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "bs58": "^4.0.1",
+        "buffer": "6.0.3",
+        "fast-stable-stringify": "^1.0.0",
+        "jayson": "^4.1.1",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^9.0.2",
+        "superstruct": "^2.0.2"
+      }
+    },
+    "node_modules/@everstake/wallet-sdk/node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "license": "MIT"
+    },
+    "node_modules/@everstake/wallet-sdk/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -3469,11 +4272,13 @@
       }
     },
     "node_modules/@fivebinaries/coin-selection": {
-      "version": "2.2.1",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@fivebinaries/coin-selection/-/coin-selection-3.0.0.tgz",
+      "integrity": "sha512-h25Pn1ZA7oqQBQDodGAgIsQt66T2wDge9onBKNqE66WNWL0KJiKJbpij8YOLo5AAlEIg5IS7EB1QjBgDOIg6DQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@emurgo/cardano-serialization-lib-browser": "^11.5.0",
-        "@emurgo/cardano-serialization-lib-nodejs": "11.5.0"
+        "@emurgo/cardano-serialization-lib-browser": "^13.2.0",
+        "@emurgo/cardano-serialization-lib-nodejs": "13.2.0"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -4672,6 +5477,8 @@
     },
     "node_modules/@mobily/ts-belt": {
       "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@mobily/ts-belt/-/ts-belt-3.13.1.tgz",
+      "integrity": "sha512-K5KqIhPI/EoCTbA6CGbrenM9s41OouyK8A03fGJJcla/zKucsgLbz8HNbeseoLarRPgyWJsUyCYqFhI7t3Ra9Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 10.*"
@@ -5010,6 +5817,8 @@
     },
     "node_modules/@noble/curves": {
       "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.4.0"
@@ -5020,6 +5829,8 @@
     },
     "node_modules/@noble/curves/node_modules/@noble/hashes": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -5296,6 +6107,8 @@
     },
     "node_modules/@scure/bip32": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.4.0",
@@ -5308,6 +6121,8 @@
     },
     "node_modules/@scure/bip32/node_modules/@noble/hashes": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -5318,7 +6133,22 @@
     },
     "node_modules/@scure/bip32/node_modules/@scure/base": {
       "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
       "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
+      "integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.4"
+      },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -5343,8 +6173,37 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@solana-program/compute-budget": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.6.1.tgz",
+      "integrity": "sha512-PWcVmRx2gSQ8jd5va5HzSlKqQmR8Q1sYaPcqpCzhOHcApJ4YsVWY6QhaOD5Nx7z1UXkP12vNq3KDsSCZnT3Hkw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/web3.js": "^2.0.0"
+      }
+    },
+    "node_modules/@solana-program/system": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.6.2.tgz",
+      "integrity": "sha512-q0ZnylK+LISjuP2jH5GWV9IJPtpzQctj5KQwij9XCDRSGkcFr2fpqptNnVupTLQiNL6Q4c1OZuG8WBmyFXVXZw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/web3.js": "^2.0.0"
+      }
+    },
     "node_modules/@solana-program/token": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.4.1.tgz",
+      "integrity": "sha512-eSYmjsapzE9jXT2J9xydlMj/zsangMEIZAy9dy75VCXM6kgDCSnH5R7+HsIoKOTvb2VggU7GojC+YhMwWGCIBw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/web3.js": "^2.0.0"
+      }
+    },
+    "node_modules/@solana-program/token-2022": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@solana-program/token-2022/-/token-2022-0.3.4.tgz",
+      "integrity": "sha512-URHA91F9sDibbL6RbuhnKHWGeAONCDcCmHq8tMtpVOhse9/WKp0JOvdLSiGuRkKZqLHo74xF8otmgPVchgVZXQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@solana/web3.js": "^2.0.0"
@@ -5352,6 +6211,8 @@
     },
     "node_modules/@solana/accounts": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.0.0.tgz",
+      "integrity": "sha512-1CE4P3QSDH5x+ZtSthMY2mn/ekROBnlT3/4f3CHDJicDvLQsgAq2yCvGHsYkK3ZA0mxhFLuhJVjuKASPnmG1rQ==",
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
@@ -5370,6 +6231,8 @@
     },
     "node_modules/@solana/addresses": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.0.0.tgz",
+      "integrity": "sha512-8n3c/mUlH1/z+pM8e7OJ6uDSXw26Be0dgYiokiqblO66DGQ0d+7pqFUFZ5pEGjJ9PU2lDTSfY8rHf4cemOqwzQ==",
       "license": "MIT",
       "dependencies": {
         "@solana/assertions": "2.0.0",
@@ -5386,6 +6249,8 @@
     },
     "node_modules/@solana/assertions": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.0.0.tgz",
+      "integrity": "sha512-NyPPqZRNGXs/GAjfgsw7YS6vCTXWt4ibXveS+ciy5sdmp/0v3pA6DlzYjleF9Sljrew0IiON15rjaXamhDxYfQ==",
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
@@ -5397,8 +6262,22 @@
         "typescript": ">=5"
       }
     },
+    "node_modules/@solana/buffer-layout": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
+      "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "~6.0.3"
+      },
+      "engines": {
+        "node": ">=5.10"
+      }
+    },
     "node_modules/@solana/codecs": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0.tgz",
+      "integrity": "sha512-xneIG5ppE6WIGaZCK7JTys0uLhzlnEJUdBO8nRVIyerwH6aqCfb0fGe7q5WNNYAVDRSxC0Pc1TDe1hpdx3KWmQ==",
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
@@ -5416,6 +6295,8 @@
     },
     "node_modules/@solana/codecs-core": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
@@ -5429,6 +6310,8 @@
     },
     "node_modules/@solana/codecs-data-structures": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
+      "integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
@@ -5444,6 +6327,8 @@
     },
     "node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
@@ -5458,6 +6343,8 @@
     },
     "node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
@@ -5474,6 +6361,8 @@
     },
     "node_modules/@solana/errors": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -5491,6 +6380,8 @@
     },
     "node_modules/@solana/errors/node_modules/chalk": {
       "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -5501,6 +6392,8 @@
     },
     "node_modules/@solana/errors/node_modules/commander": {
       "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5508,6 +6401,8 @@
     },
     "node_modules/@solana/fast-stable-stringify": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.0.0.tgz",
+      "integrity": "sha512-EsIx9z+eoxOmC+FpzhEb+H67CCYTbs/omAqXD4EdEYnCHWrI1li1oYBV+NoKzfx8fKlX+nzNB7S/9kc4u7Etpw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -5518,6 +6413,8 @@
     },
     "node_modules/@solana/functional": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.0.0.tgz",
+      "integrity": "sha512-Sj+sLiUTimnMEyGnSLGt0lbih2xPDUhxhonnrIkPwA+hjQ3ULGHAxeevHU06nqiVEgENQYUJ5rCtHs4xhUFAkQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -5528,6 +6425,8 @@
     },
     "node_modules/@solana/instructions": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.0.0.tgz",
+      "integrity": "sha512-MiTEiNF7Pzp+Y+x4yadl2VUcNHboaW5WP52psBuhHns3GpbbruRv5efMpM9OEQNe1OsN+Eg39vjEidX55+P+DQ==",
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
@@ -5541,6 +6440,8 @@
     },
     "node_modules/@solana/keys": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.0.0.tgz",
+      "integrity": "sha512-SSLSX8BXRvfLKBqsmBghmlhMKpwHeWd5CHi5zXgTS1BRrtiU6lcrTVC9ie6B+WaNNq7oe3e6K5bdbhu3fFZ+0g==",
       "license": "MIT",
       "dependencies": {
         "@solana/assertions": "2.0.0",
@@ -5557,6 +6458,8 @@
     },
     "node_modules/@solana/options": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0.tgz",
+      "integrity": "sha512-OVc4KnYosB8oAukQ/htgrxXSxlUP6gUu5Aau6d/BgEkPQzWd/Pr+w91VWw3i3zZuu2SGpedbyh05RoJBe/hSXA==",
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
@@ -5574,6 +6477,8 @@
     },
     "node_modules/@solana/programs": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.0.0.tgz",
+      "integrity": "sha512-JPIKB61pWfODnsvEAaPALc6vR5rn7kmHLpFaviWhBtfUlEVgB8yVTR0MURe4+z+fJCPRV5wWss+svA4EeGDYzQ==",
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
@@ -5588,6 +6493,8 @@
     },
     "node_modules/@solana/promises": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.0.0.tgz",
+      "integrity": "sha512-4teQ52HDjK16ORrZe1zl+Q9WcZdQ+YEl0M1gk59XG7D0P9WqaVEQzeXGnKSCs+Y9bnB1u5xCJccwpUhHYWq6gg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -5598,6 +6505,8 @@
     },
     "node_modules/@solana/rpc": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.0.0.tgz",
+      "integrity": "sha512-TumQ9DFRpib/RyaIqLVfr7UjqSo7ldfzpae0tgjM93YjbItB4Z0VcUXc3uAFvkeYw2/HIMb46Zg43mkUwozjDg==",
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0",
@@ -5619,6 +6528,8 @@
     },
     "node_modules/@solana/rpc-api": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.0.0.tgz",
+      "integrity": "sha512-1FwitYxwADMF/6zKP2kNXg8ESxB6GhNBNW1c4f5dEmuXuBbeD/enLV3WMrpg8zJkIaaYarEFNbt7R7HyFzmURQ==",
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
@@ -5642,6 +6553,8 @@
     },
     "node_modules/@solana/rpc-parsed-types": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.0.0.tgz",
+      "integrity": "sha512-VCeY/oKVEtBnp8EDOc5LSSiOeIOLFIgLndcxqU0ij/cZaQ01DOoHbhluvhZtU80Z3dUeicec8TiMgkFzed+WhQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -5652,6 +6565,8 @@
     },
     "node_modules/@solana/rpc-spec": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.0.0.tgz",
+      "integrity": "sha512-1uIDzj7vocCUqfOifjv1zAuxQ53ugiup/42edVFoQLOnJresoEZLL6WjnsJq4oCTccEAvGhUBI1WWKeZTGNxFQ==",
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0",
@@ -5666,6 +6581,8 @@
     },
     "node_modules/@solana/rpc-spec-types": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.0.0.tgz",
+      "integrity": "sha512-G2lmhFhgtxMQd/D6B04BHGE7bm5dMZdIPQNOqVGhzNAVjrmyapD3JN2hKAbmaYPe97wLfZERw0Ux1u4Y6q7TqA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -5676,6 +6593,8 @@
     },
     "node_modules/@solana/rpc-subscriptions": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.0.0.tgz",
+      "integrity": "sha512-AdwMJHMrhlj7q1MPjZmVcKq3iLqMW3N0MT8kzIAP2vP+8o/d6Fn4aqGxoz2Hlfn3OYIZoYStN2VBtwzbcfEgMA==",
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0",
@@ -5699,6 +6618,8 @@
     },
     "node_modules/@solana/rpc-subscriptions-api": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.0.0.tgz",
+      "integrity": "sha512-NAJQvSFXYIIf8zxsMFBCkSbZNZgT32pzPZ1V6ZAd+U2iDEjx3L+yFwoJgfOcHp8kAV+alsF2lIsGBlG4u+ehvw==",
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
@@ -5718,6 +6639,8 @@
     },
     "node_modules/@solana/rpc-subscriptions-channel-websocket": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.0.0.tgz",
+      "integrity": "sha512-hSQDZBmcp2t+gLZsSBqs/SqVw4RuNSC7njiP46azyzW7oGg8X2YPV36AHGsHD12KPsc0UpT1OAZ4+AN9meVKww==",
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0",
@@ -5735,6 +6658,8 @@
     },
     "node_modules/@solana/rpc-subscriptions-spec": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.0.0.tgz",
+      "integrity": "sha512-VXMiI3fYtU1PkVVTXL87pcY48ZY8aCi1N6FqtxSP2xg/GASL01j1qbwyIL1OvoCqGyRgIxdd/YfaByW9wmWBhA==",
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0",
@@ -5751,6 +6676,8 @@
     },
     "node_modules/@solana/rpc-transformers": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.0.0.tgz",
+      "integrity": "sha512-H6tN0qcqzUangowsLLQtYXKJsf1Roe3/qJ1Cy0gv9ojY9uEvNbJqpeEj+7blv0MUZfEe+rECAwBhxxRKPMhYGw==",
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0",
@@ -5767,6 +6694,8 @@
     },
     "node_modules/@solana/rpc-transport-http": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.0.0.tgz",
+      "integrity": "sha512-UJLhKhhxDd1OPi8hb2AenHsDm1mofCBbhWn4bDCnH2Q3ulwYadUhcNqNbxjJPQ774VNhAf53SSI5A6PQo8IZSQ==",
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0",
@@ -5783,10 +6712,14 @@
     },
     "node_modules/@solana/rpc-transport-http/node_modules/undici-types": {
       "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/@solana/rpc-types": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.0.0.tgz",
+      "integrity": "sha512-o1ApB9PYR0A3XjVSOh//SOVWgjDcqMlR3UNmtqciuREIBmWqnvPirdOa5EJxD3iPhfA4gnNnhGzT+tMDeDW/Kw==",
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
@@ -5804,6 +6737,8 @@
     },
     "node_modules/@solana/signers": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.0.0.tgz",
+      "integrity": "sha512-JEYJS3x/iKkqPV/3b1nLpX9lHib21wQKV3fOuu1aDLQqmX9OYKrnIIITYdnFDhmvGhpEpkkbPnqu7yVaFIBYsQ==",
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
@@ -5823,6 +6758,8 @@
     },
     "node_modules/@solana/subscribable": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.0.0.tgz",
+      "integrity": "sha512-Ex7d2GnTSNVMZDU3z6nKN4agRDDgCgBDiLnmn1hmt0iFo3alr3gRAqiqa7qGouAtYh9/29pyc8tVJCijHWJPQQ==",
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
@@ -5836,6 +6773,8 @@
     },
     "node_modules/@solana/sysvars": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.0.0.tgz",
+      "integrity": "sha512-8D4ajKcCYQsTG1p4k30lre2vjxLR6S5MftUGJnIaQObDCzGmaeA9GRti4Kk4gSPWVYFTBoj1ASx8EcEXaB3eIQ==",
       "license": "MIT",
       "dependencies": {
         "@solana/accounts": "2.0.0",
@@ -5852,6 +6791,8 @@
     },
     "node_modules/@solana/transaction-confirmation": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.0.0.tgz",
+      "integrity": "sha512-JkTw5gXLiqQjf6xK0fpVcoJ/aMp2kagtFSD/BAOazdJ3UYzOzbzqvECt6uWa3ConcMswQ2vXalVtI7ZjmYuIeg==",
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
@@ -5874,6 +6815,8 @@
     },
     "node_modules/@solana/transaction-messages": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.0.0.tgz",
+      "integrity": "sha512-Uc6Fw1EJLBrmgS1lH2ZfLAAKFvprWPQQzOVwZS78Pv8Whsk7tweYTK6S0Upv0nHr50rGpnORJfmdBrXE6OfNGg==",
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
@@ -5894,6 +6837,8 @@
     },
     "node_modules/@solana/transactions": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.0.0.tgz",
+      "integrity": "sha512-VfdTE+59WKvuBG//6iE9RPjAB+ZT2kLgY2CDHabaz6RkH6OjOkMez9fWPVa3Xtcus+YQWN1SnQoryjF/xSx04w==",
       "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
@@ -5917,6 +6862,9 @@
     },
     "node_modules/@solana/web3.js": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-2.0.0.tgz",
+      "integrity": "sha512-x+ZRB2/r5tVK/xw8QRbAfgPcX51G9f2ifEyAQ/J5npOO+6+MPeeCjtr5UxHNDAYs9Ypo0PN+YJATCO4vhzQJGg==",
+      "deprecated": "@solana/web3.js version 2.0 is now @solana/kit! Remove @solana/web3.js@2 from your dependencies and replace it with @solana/kit. As needed, upgrade all of your @solana-program/* dependencies to the latest versions that use Kit.",
       "license": "MIT",
       "dependencies": {
         "@solana/accounts": "2.0.0",
@@ -5943,6 +6891,15 @@
       },
       "peerDependencies": {
         "typescript": ">=5"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -6145,6 +7102,290 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@trezor/analytics": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@trezor/analytics/-/analytics-1.3.0.tgz",
+      "integrity": "sha512-z6dqmpK+DeJJN9cSUlOtxf0QB4dJM2rrOg0M4SMJuEZAAtEBMuhBMt2drs4KvS81ZfT8y7KOs8TvCV7Mkxxy4g==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@trezor/env-utils": "1.3.0",
+        "@trezor/utils": "9.3.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/analytics/node_modules/@trezor/env-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.3.0.tgz",
+      "integrity": "sha512-ll9RGEAFZuX/C79KU3/OTjRdD/TS0vOx0PcW6n9JtGeMrFeEwRrgVy8+0OcFcYODSdzsWLhwB9XHPaLPC3tOCQ==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "ua-parser-js": "^1.0.37"
+      },
+      "peerDependencies": {
+        "expo-constants": "*",
+        "expo-localization": "*",
+        "react-native": "*",
+        "tslib": "^2.6.2"
+      },
+      "peerDependenciesMeta": {
+        "expo-constants": {
+          "optional": true
+        },
+        "expo-localization": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trezor/blockchain-link": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link/-/blockchain-link-2.4.0.tgz",
+      "integrity": "sha512-oZIf9MY7NU/kZwe6nxIRpbyuW/1loaC19tQCRdNac3nUdKKfGpS4Km9dXjau9rdq9ZzoXiBPdmJ28IF8Fbf37A==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@everstake/wallet-sdk": "^1.0.10",
+        "@solana-program/token": "^0.4.1",
+        "@solana-program/token-2022": "^0.3.4",
+        "@solana/web3.js": "^2.0.0",
+        "@trezor/blockchain-link-types": "1.3.0",
+        "@trezor/blockchain-link-utils": "1.3.0",
+        "@trezor/env-utils": "1.3.0",
+        "@trezor/utils": "9.3.0",
+        "@trezor/utxo-lib": "2.3.0",
+        "@trezor/websocket-client": "1.1.0",
+        "@types/web": "^0.0.197",
+        "events": "^3.3.0",
+        "ripple-lib": "^1.10.1",
+        "socks-proxy-agent": "8.0.4"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-types": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-types/-/blockchain-link-types-1.3.0.tgz",
+      "integrity": "sha512-NTMFrDzNyAoqE1556UVp63KuCkrpZa3Lv4SKWOpIovkQP0kk4trMKRZua1phqOFdPHUw2lWRxOzvCHq6xOnzmg==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@everstake/wallet-sdk": "^1.0.10",
+        "@solana/web3.js": "^2.0.0",
+        "@trezor/type-utils": "1.1.4",
+        "@trezor/utxo-lib": "2.3.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-utils/-/blockchain-link-utils-1.3.0.tgz",
+      "integrity": "sha512-RDosOutSlltckmetUq+02XqwkiZVNYwSh82SpD/ZWQKjohZT5Cv6L9RMGt34+UurZXPUxFOvHQj1gBc+DIamkw==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@everstake/wallet-sdk": "^1.0.10",
+        "@mobily/ts-belt": "^3.13.1",
+        "@trezor/env-utils": "1.3.0",
+        "@trezor/utils": "9.3.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils/node_modules/@trezor/env-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.3.0.tgz",
+      "integrity": "sha512-ll9RGEAFZuX/C79KU3/OTjRdD/TS0vOx0PcW6n9JtGeMrFeEwRrgVy8+0OcFcYODSdzsWLhwB9XHPaLPC3tOCQ==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "ua-parser-js": "^1.0.37"
+      },
+      "peerDependencies": {
+        "expo-constants": "*",
+        "expo-localization": "*",
+        "react-native": "*",
+        "tslib": "^2.6.2"
+      },
+      "peerDependenciesMeta": {
+        "expo-constants": {
+          "optional": true
+        },
+        "expo-localization": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@trezor/env-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.3.0.tgz",
+      "integrity": "sha512-ll9RGEAFZuX/C79KU3/OTjRdD/TS0vOx0PcW6n9JtGeMrFeEwRrgVy8+0OcFcYODSdzsWLhwB9XHPaLPC3tOCQ==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "ua-parser-js": "^1.0.37"
+      },
+      "peerDependencies": {
+        "expo-constants": "*",
+        "expo-localization": "*",
+        "react-native": "*",
+        "tslib": "^2.6.2"
+      },
+      "peerDependenciesMeta": {
+        "expo-constants": {
+          "optional": true
+        },
+        "expo-localization": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trezor/connect": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/connect/-/connect-9.5.0.tgz",
+      "integrity": "sha512-xvt5TK0uNgVvfLx7MC0Bqwt2FesEmo8iPaOV73KRHqx2uzqZoYwRuHRmL2UN/eMyxRIZgCmaZZXlflRLTXVFgw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@babel/preset-typescript": "^7.24.7",
+        "@ethereumjs/common": "^4.4.0",
+        "@ethereumjs/tx": "^5.4.0",
+        "@fivebinaries/coin-selection": "3.0.0",
+        "@mobily/ts-belt": "^3.13.1",
+        "@noble/hashes": "^1.6.1",
+        "@scure/bip39": "^1.5.1",
+        "@solana-program/compute-budget": "^0.6.1",
+        "@solana-program/system": "^0.6.2",
+        "@solana-program/token": "^0.4.1",
+        "@solana-program/token-2022": "^0.3.4",
+        "@solana/web3.js": "^2.0.0",
+        "@trezor/blockchain-link": "2.4.0",
+        "@trezor/blockchain-link-types": "1.3.0",
+        "@trezor/blockchain-link-utils": "1.3.0",
+        "@trezor/connect-analytics": "1.3.0",
+        "@trezor/connect-common": "0.3.0",
+        "@trezor/crypto-utils": "1.1.0",
+        "@trezor/protobuf": "1.3.0",
+        "@trezor/protocol": "1.2.2",
+        "@trezor/schema-utils": "1.3.0",
+        "@trezor/transport": "1.4.0",
+        "@trezor/utils": "9.3.0",
+        "@trezor/utxo-lib": "2.3.0",
+        "blakejs": "^1.2.1",
+        "bs58": "^6.0.0",
+        "bs58check": "^4.0.0",
+        "cross-fetch": "^4.0.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-analytics": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-analytics/-/connect-analytics-1.3.0.tgz",
+      "integrity": "sha512-DCKVnnCB7h+XysUKzghVg2PY/5zETt2dkbKtywwd/uRgnXH3LuFajVj60s1eTOLzSakUaUHr5i+v+Gi2Poz4yA==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@trezor/analytics": "1.3.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-common": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-0.3.0.tgz",
+      "integrity": "sha512-7hjIuXAFxKZp72u2oESuxUFx77onLMOyWNVZf0uOaC6WBfhux7ZYgY+9+qGiV9SYD6xpdLRhrlKerxtQn78eng==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@trezor/env-utils": "1.3.0",
+        "@trezor/utils": "9.3.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-common/node_modules/@trezor/env-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.3.0.tgz",
+      "integrity": "sha512-ll9RGEAFZuX/C79KU3/OTjRdD/TS0vOx0PcW6n9JtGeMrFeEwRrgVy8+0OcFcYODSdzsWLhwB9XHPaLPC3tOCQ==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "ua-parser-js": "^1.0.37"
+      },
+      "peerDependencies": {
+        "expo-constants": "*",
+        "expo-localization": "*",
+        "react-native": "*",
+        "tslib": "^2.6.2"
+      },
+      "peerDependenciesMeta": {
+        "expo-constants": {
+          "optional": true
+        },
+        "expo-localization": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trezor/connect-web": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-web/-/connect-web-9.5.0.tgz",
+      "integrity": "sha512-ykMRkFoS/kSFYO0lH5Ymv+znIbIHNLnuw3NFfKL26uBYJEg/l28K3QCyvjwM5J/D9EcJjv1Yh4GLKw6zJjD60w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@trezor/connect": "9.5.0",
+        "@trezor/connect-common": "0.3.0",
+        "@trezor/utils": "9.3.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
+    "node_modules/@trezor/connect/node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/bs58check": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^6.0.0"
+      }
+    },
+    "node_modules/@trezor/crypto-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@trezor/crypto-utils/-/crypto-utils-1.1.0.tgz",
+      "integrity": "sha512-Uej/0tM9ElOdh+zSHkNZ2fV3NhxhB05tb8rQrboWQ711h2NmKYTpza0KwqLn1riVFQU35+6ok4WxmdB6iPP1gA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
     "node_modules/@trezor/protobuf": {
       "version": "1.3.0",
       "license": "See LICENSE.md in repo root",
@@ -6192,6 +7433,8 @@
     },
     "node_modules/@trezor/type-utils": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@trezor/type-utils/-/type-utils-1.1.4.tgz",
+      "integrity": "sha512-pzrIdskmTZRocHellMZxCDPQ3IpmTr749qn1xdIN29pIKuI4ms0OfNUPk/rfR4Iug0kEiWt+n+Hw7+lIBzc2LA==",
       "license": "See LICENSE.md in repo root"
     },
     "node_modules/@trezor/utils": {
@@ -6199,6 +7442,117 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "bignumber.js": "^9.1.2"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/utxo-lib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@trezor/utxo-lib/-/utxo-lib-2.3.0.tgz",
+      "integrity": "sha512-YvMdvOvX0v1KSzUelz8TfZDo/6hTR4GvIRKCiq2rIT1XmxeZiP8FYuOUcAL7YqL8tdKTPiMXzw2k9LSsdhvOrQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@trezor/utils": "9.3.0",
+        "bchaddrjs": "^0.5.2",
+        "bech32": "^2.0.0",
+        "bip66": "^2.0.0",
+        "bitcoin-ops": "^1.4.1",
+        "blake-hash": "^2.0.0",
+        "blakejs": "^1.2.1",
+        "bn.js": "^5.2.1",
+        "bs58": "^6.0.0",
+        "bs58check": "^4.0.0",
+        "create-hmac": "^1.1.7",
+        "int64-buffer": "^1.1.0",
+        "pushdata-bitcoin": "^1.0.1",
+        "tiny-secp256k1": "^1.1.6",
+        "typeforce": "^1.18.0",
+        "varuint-bitcoin": "2.0.0",
+        "wif": "^5.0.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/utxo-lib/node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
+    "node_modules/@trezor/utxo-lib/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "license": "MIT"
+    },
+    "node_modules/@trezor/utxo-lib/node_modules/bip66": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-2.0.0.tgz",
+      "integrity": "sha512-kBG+hSpgvZBrkIm9dt5T1Hd/7xGCPEX2npoxAWZfsK1FvjgaxySEh2WizjyIstWXriKo9K9uJ4u0OnsyLDUPXQ==",
+      "license": "MIT"
+    },
+    "node_modules/@trezor/utxo-lib/node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "license": "MIT"
+    },
+    "node_modules/@trezor/utxo-lib/node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/@trezor/utxo-lib/node_modules/bs58check": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^6.0.0"
+      }
+    },
+    "node_modules/@trezor/utxo-lib/node_modules/uint8array-tools": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
+      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@trezor/utxo-lib/node_modules/varuint-bitcoin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-2.0.0.tgz",
+      "integrity": "sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog==",
+      "license": "MIT",
+      "dependencies": {
+        "uint8array-tools": "^0.0.8"
+      }
+    },
+    "node_modules/@trezor/utxo-lib/node_modules/wif": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-5.0.0.tgz",
+      "integrity": "sha512-iFzrC/9ne740qFbNjTZ2FciSRJlHIXoxqk/Y5EnE08QOXu1WjJyCCswwDTYbohAOEnlCtLaAAQBhyaLRFh2hMA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58check": "^4.0.0"
+      }
+    },
+    "node_modules/@trezor/websocket-client": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@trezor/websocket-client/-/websocket-client-1.1.0.tgz",
+      "integrity": "sha512-7KD1Ive8jMcGpdTAHmV1FPCFUjqYiV/2kGJHBqoLXx4kkvkMU9n9++WieD2W7YVDM3uXuIoRvGYRnZDjcFuEdw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@trezor/utils": "9.3.0",
+        "ws": "^8.18.0"
       },
       "peerDependencies": {
         "tslib": "^2.6.2"
@@ -6264,6 +7618,15 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -6379,7 +7742,9 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.202",
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
       "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
@@ -6534,6 +7899,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "license": "MIT"
+    },
     "node_modules/@types/w3c-web-usb": {
       "version": "1.0.10",
       "license": "MIT"
@@ -6542,8 +7913,16 @@
       "version": "3.0.3",
       "license": "MIT"
     },
+    "node_modules/@types/web": {
+      "version": "0.0.197",
+      "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.197.tgz",
+      "integrity": "sha512-V4sOroWDADFx9dLodWpKm298NOJ1VJ6zoDVgaP+WBb/utWxqQ6gnMzd9lvVDAr/F3ibiKaxH9i45eS0gQPSTaQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@types/ws": {
       "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -7129,6 +8508,21 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/abitype": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.7.1.tgz",
+      "integrity": "sha512-VBkRHTDZf9Myaek/dO3yMmOzB/y2s3Zo6nVU7yaw1G+TvCHAjwaJzNGN9yo4K5D8bU/VZXKP1EJpRhFr862PlQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=4.9.4",
+        "zod": "^3 >=3.19.1"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "dev": true,
@@ -7182,6 +8576,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+      "license": "MIT"
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "license": "MIT",
@@ -7190,6 +8590,18 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -7868,6 +9280,8 @@
     },
     "node_modules/bchaddrjs": {
       "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/bchaddrjs/-/bchaddrjs-0.5.2.tgz",
+      "integrity": "sha512-OO7gIn3m7ea4FVx4cT8gdlWQR2+++EquhdpWQJH9BQjK63tJJ6ngB3QMZDO6DiBoXiIGUsTPHjlrHVxPGcGxLQ==",
       "license": "MIT",
       "dependencies": {
         "bs58check": "2.1.2",
@@ -7896,9 +9310,24 @@
     },
     "node_modules/big-integer": {
       "version": "1.6.36",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==",
       "license": "Unlicense",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/bigint-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bindings": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/bignumber.js": {
@@ -8070,6 +9499,8 @@
     },
     "node_modules/blake-hash": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/blake-hash/-/blake-hash-2.0.0.tgz",
+      "integrity": "sha512-Igj8YowDu1PRkRsxZA7NVkdFNxH5rKv5cpLxQ0CVXSIA77pVYwCPRQJ2sMew/oneUpfuYRyjG6r8SmmmnbZb1w==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -8083,6 +9514,8 @@
     },
     "node_modules/blakejs": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
       "license": "MIT"
     },
     "node_modules/bluebird": {
@@ -8093,6 +9526,32 @@
     "node_modules/bn.js": {
       "version": "4.12.0",
       "license": "MIT"
+    },
+    "node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
+    },
+    "node_modules/borsh/node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "license": "MIT"
+    },
+    "node_modules/borsh/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
     },
     "node_modules/bowser": {
       "version": "2.11.0",
@@ -8336,7 +9795,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -8473,6 +9931,8 @@
     },
     "node_modules/cashaddrjs": {
       "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cashaddrjs/-/cashaddrjs-0.4.4.tgz",
+      "integrity": "sha512-xZkuWdNOh0uq/mxJIng6vYWfTowZLd9F4GMAlp2DwFHlcCqCm91NtuAc47RuV4L7r4PYcY5p6Cr2OKNb4hnkWA==",
       "license": "MIT",
       "dependencies": {
         "big-integer": "1.6.36"
@@ -8764,7 +10224,6 @@
     },
     "node_modules/commander": {
       "version": "2.20.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commondir": {
@@ -9114,6 +10573,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/create-ecdh": {
@@ -9545,6 +11016,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
@@ -10013,6 +11496,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
+    "node_modules/es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^4.0.3"
       }
     },
     "node_modules/esbuild": {
@@ -10875,6 +12373,8 @@
     },
     "node_modules/ethereum-cryptography": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
+      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "1.4.2",
@@ -10885,6 +12385,8 @@
     },
     "node_modules/ethereum-cryptography/node_modules/@noble/hashes": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -10895,6 +12397,8 @@
     },
     "node_modules/ethereum-cryptography/node_modules/@scure/base": {
       "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -10902,6 +12406,8 @@
     },
     "node_modules/ethereum-cryptography/node_modules/@scure/bip39": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "~1.4.0",
@@ -10911,9 +12417,66 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/ethereum-multicall": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/ethereum-multicall/-/ethereum-multicall-2.26.0.tgz",
+      "integrity": "sha512-7PslfFiHPUrA0zQpMgZdftUBNyVWuHVBwnRtDOr6Eam8O/OwucqP+OHZZDE7qdrWzi4Jrji8IMw2ZUFv/wbs8Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@ethersproject/providers": "^5.0.10",
+        "ethers": "^5.0.15"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.8.0.tgz",
+      "integrity": "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abi": "5.8.0",
+        "@ethersproject/abstract-provider": "5.8.0",
+        "@ethersproject/abstract-signer": "5.8.0",
+        "@ethersproject/address": "5.8.0",
+        "@ethersproject/base64": "5.8.0",
+        "@ethersproject/basex": "5.8.0",
+        "@ethersproject/bignumber": "5.8.0",
+        "@ethersproject/bytes": "5.8.0",
+        "@ethersproject/constants": "5.8.0",
+        "@ethersproject/contracts": "5.8.0",
+        "@ethersproject/hash": "5.8.0",
+        "@ethersproject/hdnode": "5.8.0",
+        "@ethersproject/json-wallets": "5.8.0",
+        "@ethersproject/keccak256": "5.8.0",
+        "@ethersproject/logger": "5.8.0",
+        "@ethersproject/networks": "5.8.0",
+        "@ethersproject/pbkdf2": "5.8.0",
+        "@ethersproject/properties": "5.8.0",
+        "@ethersproject/providers": "5.8.0",
+        "@ethersproject/random": "5.8.0",
+        "@ethersproject/rlp": "5.8.0",
+        "@ethersproject/sha2": "5.8.0",
+        "@ethersproject/signing-key": "5.8.0",
+        "@ethersproject/solidity": "5.8.0",
+        "@ethersproject/strings": "5.8.0",
+        "@ethersproject/transactions": "5.8.0",
+        "@ethersproject/units": "5.8.0",
+        "@ethersproject/wallet": "5.8.0",
+        "@ethersproject/web": "5.8.0",
+        "@ethersproject/wordlists": "5.8.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
@@ -11005,6 +12568,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "engines": {
+        "node": "> 0.1.90"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
@@ -11040,8 +12611,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-stable-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
+      "license": "MIT"
+    },
     "node_modules/fastestsmallesttextencoderdecoder": {
       "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
       "license": "CC0-1.0",
       "peer": true
     },
@@ -12019,6 +13598,15 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
     "node_modules/husky": {
       "version": "4.3.8",
       "dev": true,
@@ -12302,6 +13890,8 @@
     },
     "node_modules/int64-buffer": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.0.tgz",
+      "integrity": "sha512-94smTCQOvigN4d/2R/YDjz8YVG0Sufvv2aAh8P5m42gwhCsDAJqnbNOrxJsrADuAFAA69Q/ptGzxvNcNuIJcvw==",
       "license": "MIT"
     },
     "node_modules/internal-slot": {
@@ -12326,6 +13916,8 @@
     },
     "node_modules/ip-address": {
       "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
       "license": "MIT",
       "dependencies": {
         "jsbn": "1.1.0",
@@ -12337,6 +13929,8 @@
     },
     "node_modules/ip-address/node_modules/sprintf-js": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/is-arguments": {
@@ -12792,6 +14386,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "dev": true,
@@ -12951,6 +14554,77 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jayson": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.3.tgz",
+      "integrity": "sha512-LtXh5aYZodBZ9Fc3j6f2w+MTNcnxteMOrb+QgIouguGOulWi0lieEkOUg+HkjjFs0DGoWDds6bi4E9hpNFLulQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "^3.4.33",
+        "@types/node": "^12.12.54",
+        "@types/ws": "^7.4.4",
+        "commander": "^2.20.3",
+        "delay": "^5.0.0",
+        "es6-promisify": "^5.0.0",
+        "eyes": "^0.1.8",
+        "isomorphic-ws": "^4.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "JSONStream": "^1.3.5",
+        "uuid": "^8.3.2",
+        "ws": "^7.5.10"
+      },
+      "bin": {
+        "jayson": "bin/jayson.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jayson/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/jayson/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/jayson/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest": {
@@ -14725,6 +16399,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
@@ -14751,6 +16431,8 @@
     },
     "node_modules/jsbn": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "license": "MIT"
     },
     "node_modules/jsdoc": {
@@ -14888,7 +16570,6 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/json5": {
@@ -14913,7 +16594,6 @@
     },
     "node_modules/jsonparse": {
       "version": "1.3.1",
-      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -14921,6 +16601,8 @@
     },
     "node_modules/jsonschema": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
+      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA==",
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -14928,7 +16610,6 @@
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
-      "dev": true,
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "jsonparse": "^1.2.0",
@@ -16590,6 +18271,8 @@
     },
     "node_modules/node-addon-api": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
       "license": "MIT"
     },
     "node_modules/node-fetch": {
@@ -18649,6 +20332,8 @@
     },
     "node_modules/ripple-address-codec": {
       "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-4.3.1.tgz",
+      "integrity": "sha512-Qa3+9wKVvpL/xYtT6+wANsn0A1QcC5CT6IMZbRJZ/1lGt7gmwIfsrCuz1X0+LCEO7zgb+3UT1I1dc0k/5dwKQQ==",
       "license": "ISC",
       "dependencies": {
         "base-x": "^3.0.9",
@@ -18660,6 +20345,8 @@
     },
     "node_modules/ripple-binary-codec": {
       "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-1.11.0.tgz",
+      "integrity": "sha512-g7+gs3T+NfoeW6vIq5dcN0CkIT4t/zwRzFxz8X2RzfbrWRnewPUKqQbmBgs05tXLX5NuWPaneiaAVpFpYBcdfw==",
       "license": "ISC",
       "dependencies": {
         "assert": "^2.0.0",
@@ -18675,6 +20362,8 @@
     },
     "node_modules/ripple-binary-codec/node_modules/big-integer": {
       "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
       "license": "Unlicense",
       "engines": {
         "node": ">=0.6"
@@ -18682,6 +20371,8 @@
     },
     "node_modules/ripple-keypairs": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-1.3.1.tgz",
+      "integrity": "sha512-dmPlraWKJciFJxHcoubDahGnoIalG5e/BtV6HNDUs7wLXmtnLMHt6w4ed9R8MTL2zNrVPiIdI/HCtMMo0Tm7JQ==",
       "license": "ISC",
       "dependencies": {
         "bn.js": "^5.1.1",
@@ -18696,10 +20387,15 @@
     },
     "node_modules/ripple-keypairs/node_modules/bn.js": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
       "license": "MIT"
     },
     "node_modules/ripple-lib": {
       "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/ripple-lib/-/ripple-lib-1.10.1.tgz",
+      "integrity": "sha512-OQk+Syl2JfxKxV2KuF/kBMtnh012I5tNnziP3G4WDGCGSIAgeqkOgkR59IQ0YDNrs1YW8GbApxrdMSRi/QClcA==",
+      "deprecated": "ripple-lib is deprecated. Please migrate to xrpl.js using this migration guide: https://xrpl.org/xrpljs2-migration-guide.html",
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.14.136",
@@ -18721,6 +20417,8 @@
     },
     "node_modules/ripple-lib-transactionparser": {
       "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/ripple-lib-transactionparser/-/ripple-lib-transactionparser-0.8.2.tgz",
+      "integrity": "sha512-1teosQLjYHLyOQrKUQfYyMjDR3MAq/Ga+MJuLUfpBMypl4LZB4bEoMcmG99/+WVTEiZOezJmH9iCSvm/MyxD+g==",
       "license": "ISC",
       "dependencies": {
         "bignumber.js": "^9.0.0",
@@ -18729,6 +20427,8 @@
     },
     "node_modules/ripple-lib/node_modules/ws": {
       "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -18757,6 +20457,47 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rpc-websockets": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.1.1.tgz",
+      "integrity": "sha512-1IXGM/TfPT6nfYMIXkJdzn+L4JEsmb0FL1O2OBjaH03V3yuUDdKFulGLMFG6ErV+8pZ5HVC0limve01RyO+saA==",
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/uuid": "^8.3.4",
+        "@types/ws": "^8.2.2",
+        "buffer": "^6.0.3",
+        "eventemitter3": "^5.0.1",
+        "uuid": "^8.3.2",
+        "ws": "^8.5.0"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/kozjak"
+      },
+      "optionalDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/rrweb-cssom": {
@@ -18890,6 +20631,12 @@
         "object-assign": "^4.1.1"
       }
     },
+    "node_modules/scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "license": "ISC",
@@ -18951,7 +20698,6 @@
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sha": {
@@ -19083,6 +20829,8 @@
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
@@ -19091,6 +20839,8 @@
     },
     "node_modules/socks": {
       "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "^9.0.5",
@@ -19103,6 +20853,8 @@
     },
     "node_modules/socks-proxy-agent": {
       "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+      "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.1",
@@ -19115,6 +20867,8 @@
     },
     "node_modules/socks-proxy-agent/node_modules/agent-base": {
       "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -19670,6 +21424,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/superstruct": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "dev": true,
@@ -19809,6 +21572,11 @@
         "node": "*"
       }
     },
+    "node_modules/text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
+    },
     "node_modules/text-extensions": {
       "version": "1.9.0",
       "dev": true,
@@ -19851,7 +21619,6 @@
     },
     "node_modules/through": {
       "version": "2.3.8",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/through2": {
@@ -20505,7 +22272,9 @@
       "license": "MIT"
     },
     "node_modules/ua-parser-js": {
-      "version": "1.0.37",
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.40.tgz",
+      "integrity": "sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==",
       "funding": [
         {
           "type": "opencollective",
@@ -20521,6 +22290,9 @@
         }
       ],
       "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
       "engines": {
         "node": "*"
       }
@@ -20730,7 +22502,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -21552,6 +23323,382 @@
         "node": ">= 8"
       }
     },
+    "node_modules/web3": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-4.16.0.tgz",
+      "integrity": "sha512-SgoMSBo6EsJ5GFCGar2E/pR2lcR/xmUSuQ61iK6yDqzxmm42aPPxSqZfJz2z/UCR6pk03u77pU8TGV6lgMDdIQ==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-core": "^4.7.1",
+        "web3-errors": "^1.3.1",
+        "web3-eth": "^4.11.1",
+        "web3-eth-abi": "^4.4.1",
+        "web3-eth-accounts": "^4.3.1",
+        "web3-eth-contract": "^4.7.2",
+        "web3-eth-ens": "^4.4.0",
+        "web3-eth-iban": "^4.0.7",
+        "web3-eth-personal": "^4.1.0",
+        "web3-net": "^4.1.0",
+        "web3-providers-http": "^4.2.0",
+        "web3-providers-ws": "^4.0.8",
+        "web3-rpc-methods": "^1.3.0",
+        "web3-rpc-providers": "^1.0.0-rc.4",
+        "web3-types": "^1.10.0",
+        "web3-utils": "^4.3.3",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-core": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-4.7.1.tgz",
+      "integrity": "sha512-9KSeASCb/y6BG7rwhgtYC4CvYY66JfkmGNEYb7q1xgjt9BWfkf09MJPaRyoyT5trdOxYDHkT9tDlypvQWaU8UQ==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-errors": "^1.3.1",
+        "web3-eth-accounts": "^4.3.1",
+        "web3-eth-iban": "^4.0.7",
+        "web3-providers-http": "^4.2.0",
+        "web3-providers-ws": "^4.0.8",
+        "web3-types": "^1.10.0",
+        "web3-utils": "^4.3.3",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      },
+      "optionalDependencies": {
+        "web3-providers-ipc": "^4.0.7"
+      }
+    },
+    "node_modules/web3-errors": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/web3-errors/-/web3-errors-1.3.1.tgz",
+      "integrity": "sha512-w3NMJujH+ZSW4ltIZZKtdbkbyQEvBzyp3JRn59Ckli0Nz4VMsVq8aF1bLWM7A2kuQ+yVEm3ySeNU+7mSRwx7RQ==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-types": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-eth": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-4.11.1.tgz",
+      "integrity": "sha512-q9zOkzHnbLv44mwgLjLXuyqszHuUgZWsQayD2i/rus2uk0G7hMn11bE2Q3hOVnJS4ws4VCtUznlMxwKQ+38V2w==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "setimmediate": "^1.0.5",
+        "web3-core": "^4.7.1",
+        "web3-errors": "^1.3.1",
+        "web3-eth-abi": "^4.4.1",
+        "web3-eth-accounts": "^4.3.1",
+        "web3-net": "^4.1.0",
+        "web3-providers-ws": "^4.0.8",
+        "web3-rpc-methods": "^1.3.0",
+        "web3-types": "^1.10.0",
+        "web3-utils": "^4.3.3",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-eth-abi": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-4.4.1.tgz",
+      "integrity": "sha512-60ecEkF6kQ9zAfbTY04Nc9q4eEYM0++BySpGi8wZ2PD1tw/c0SDvsKhV6IKURxLJhsDlb08dATc3iD6IbtWJmg==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "abitype": "0.7.1",
+        "web3-errors": "^1.3.1",
+        "web3-types": "^1.10.0",
+        "web3-utils": "^4.3.3",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-eth-accounts": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-4.3.1.tgz",
+      "integrity": "sha512-rTXf+H9OKze6lxi7WMMOF1/2cZvJb2AOnbNQxPhBDssKOllAMzLhg1FbZ4Mf3lWecWfN6luWgRhaeSqO1l+IBQ==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@ethereumjs/rlp": "^4.0.1",
+        "crc-32": "^1.2.2",
+        "ethereum-cryptography": "^2.0.0",
+        "web3-errors": "^1.3.1",
+        "web3-types": "^1.10.0",
+        "web3-utils": "^4.3.3",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-eth-accounts/node_modules/@ethereumjs/rlp": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-4.0.1.tgz",
+      "integrity": "sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==",
+      "license": "MPL-2.0",
+      "bin": {
+        "rlp": "bin/rlp"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/web3-eth-contract": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-4.7.2.tgz",
+      "integrity": "sha512-3ETqs2pMNPEAc7BVY/C3voOhTUeJdkf2aM3X1v+edbngJLHAxbvxKpOqrcO0cjXzC4uc2Q8Zpf8n8zT5r0eLnA==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@ethereumjs/rlp": "^5.0.2",
+        "web3-core": "^4.7.1",
+        "web3-errors": "^1.3.1",
+        "web3-eth": "^4.11.1",
+        "web3-eth-abi": "^4.4.1",
+        "web3-types": "^1.10.0",
+        "web3-utils": "^4.3.3",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-eth-ens": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-4.4.0.tgz",
+      "integrity": "sha512-DeyVIS060hNV9g8dnTx92syqvgbvPricE3MerCxe/DquNZT3tD8aVgFfq65GATtpCgDDJffO2bVeHp3XBemnSQ==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.8.8",
+        "web3-core": "^4.5.0",
+        "web3-errors": "^1.2.0",
+        "web3-eth": "^4.8.0",
+        "web3-eth-contract": "^4.5.0",
+        "web3-net": "^4.1.0",
+        "web3-types": "^1.7.0",
+        "web3-utils": "^4.3.0",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-eth-iban": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-4.0.7.tgz",
+      "integrity": "sha512-8weKLa9KuKRzibC87vNLdkinpUE30gn0IGY027F8doeJdcPUfsa4IlBgNC4k4HLBembBB2CTU0Kr/HAOqMeYVQ==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-errors": "^1.1.3",
+        "web3-types": "^1.3.0",
+        "web3-utils": "^4.0.7",
+        "web3-validator": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-eth-personal": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-4.1.0.tgz",
+      "integrity": "sha512-RFN83uMuvA5cu1zIwwJh9A/bAj0OBxmGN3tgx19OD/9ygeUZbifOL06jgFzN0t+1ekHqm3DXYQM8UfHpXi7yDQ==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-core": "^4.6.0",
+        "web3-eth": "^4.9.0",
+        "web3-rpc-methods": "^1.3.0",
+        "web3-types": "^1.8.0",
+        "web3-utils": "^4.3.1",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-net": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-4.1.0.tgz",
+      "integrity": "sha512-WWmfvHVIXWEoBDWdgKNYKN8rAy6SgluZ0abyRyXOL3ESr7ym7pKWbfP4fjApIHlYTh8tNqkrdPfM4Dyi6CA0SA==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-core": "^4.4.0",
+        "web3-rpc-methods": "^1.3.0",
+        "web3-types": "^1.6.0",
+        "web3-utils": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-providers-http": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-4.2.0.tgz",
+      "integrity": "sha512-IPMnDtHB7dVwaB7/mMxAZzyq7d5ezfO1+Vw0bNfAeIi7gaDlJiggp85SdyAfOgov8AMUA/dyiY72kQ0KmjXKvQ==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "cross-fetch": "^4.0.0",
+        "web3-errors": "^1.3.0",
+        "web3-types": "^1.7.0",
+        "web3-utils": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-providers-ipc": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-4.0.7.tgz",
+      "integrity": "sha512-YbNqY4zUvIaK2MHr1lQFE53/8t/ejHtJchrWn9zVbFMGXlTsOAbNoIoZWROrg1v+hCBvT2c9z8xt7e/+uz5p1g==",
+      "license": "LGPL-3.0",
+      "optional": true,
+      "dependencies": {
+        "web3-errors": "^1.1.3",
+        "web3-types": "^1.3.0",
+        "web3-utils": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-providers-ws": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-4.0.8.tgz",
+      "integrity": "sha512-goJdgata7v4pyzHRsg9fSegUG4gVnHZSHODhNnn6J93ykHkBI1nz4fjlGpcQLUMi4jAMz6SHl9Ibzs2jj9xqPw==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@types/ws": "8.5.3",
+        "isomorphic-ws": "^5.0.0",
+        "web3-errors": "^1.2.0",
+        "web3-types": "^1.7.0",
+        "web3-utils": "^4.3.1",
+        "ws": "^8.17.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-providers-ws/node_modules/@types/ws": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/web3-rpc-methods": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-rpc-methods/-/web3-rpc-methods-1.3.0.tgz",
+      "integrity": "sha512-/CHmzGN+IYgdBOme7PdqzF+FNeMleefzqs0LVOduncSaqsppeOEoskLXb2anSpzmQAP3xZJPaTrkQPWSJMORig==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-core": "^4.4.0",
+        "web3-types": "^1.6.0",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-rpc-providers": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/web3-rpc-providers/-/web3-rpc-providers-1.0.0-rc.4.tgz",
+      "integrity": "sha512-PXosCqHW0EADrYzgmueNHP3Y5jcSmSwH+Dkqvn7EYD0T2jcsdDAIHqk6szBiwIdhumM7gv9Raprsu/s/f7h1fw==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-errors": "^1.3.1",
+        "web3-providers-http": "^4.2.0",
+        "web3-providers-ws": "^4.0.8",
+        "web3-types": "^1.10.0",
+        "web3-utils": "^4.3.3",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-types": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/web3-types/-/web3-types-1.10.0.tgz",
+      "integrity": "sha512-0IXoaAFtFc8Yin7cCdQfB9ZmjafrbP6BO0f0KT/khMhXKUpoJ6yShrVhiNpyRBo8QQjuOagsWzwSK2H49I7sbw==",
+      "license": "LGPL-3.0",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-4.3.3.tgz",
+      "integrity": "sha512-kZUeCwaQm+RNc2Bf1V3BYbF29lQQKz28L0y+FA4G0lS8IxtJVGi5SeDTUkpwqqkdHHC7JcapPDnyyzJ1lfWlOw==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "ethereum-cryptography": "^2.0.0",
+        "eventemitter3": "^5.0.1",
+        "web3-errors": "^1.3.1",
+        "web3-types": "^1.10.0",
+        "web3-validator": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-validator": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/web3-validator/-/web3-validator-2.0.6.tgz",
+      "integrity": "sha512-qn9id0/l1bWmvH4XfnG/JtGKKwut2Vokl6YXP5Kfg424npysmtRLe9DgiNBM9Op7QL/aSiaA0TVXibuIuWcizg==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "ethereum-cryptography": "^2.0.0",
+        "util": "^0.12.5",
+        "web3-errors": "^1.2.0",
+        "web3-types": "^1.6.0",
+        "zod": "^3.21.4"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.12.0"
+      }
+    },
+    "node_modules/web3-validator/node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/webcrypto-core": {
       "version": "1.7.9",
       "dev": true,
@@ -22001,6 +24148,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "packages/bip32": {
@@ -25100,254 +27256,6 @@
         "node": ">= 6"
       }
     },
-    "packages/caravan-wallets/node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/analytics": {
-      "version": "1.2.5",
-      "license": "See LICENSE.md in repo root",
-      "dependencies": {
-        "@trezor/env-utils": "1.2.1",
-        "@trezor/utils": "9.2.5"
-      },
-      "peerDependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/analytics/node_modules/@trezor/utils": {
-      "version": "9.2.5",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "bignumber.js": "^9.1.2"
-      },
-      "peerDependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/analytics/node_modules/bignumber.js": {
-      "version": "9.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/blockchain-link": {
-      "version": "2.3.6",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@solana-program/token": "^0.4.1",
-        "@solana/web3.js": "^2.0.0",
-        "@trezor/blockchain-link-types": "1.2.5",
-        "@trezor/blockchain-link-utils": "1.2.6",
-        "@trezor/env-utils": "1.2.1",
-        "@trezor/utils": "9.2.6",
-        "@trezor/utxo-lib": "2.2.6",
-        "@types/web": "^0.0.174",
-        "events": "^3.3.0",
-        "ripple-lib": "^1.10.1",
-        "socks-proxy-agent": "8.0.4",
-        "ws": "^8.18.0"
-      },
-      "peerDependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/blockchain-link-types": {
-      "version": "1.2.5",
-      "license": "See LICENSE.md in repo root",
-      "dependencies": {
-        "@solana/web3.js": "^2.0.0",
-        "@trezor/type-utils": "1.1.4",
-        "@trezor/utxo-lib": "2.2.6"
-      },
-      "peerDependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/blockchain-link-utils": {
-      "version": "1.2.6",
-      "license": "See LICENSE.md in repo root",
-      "dependencies": {
-        "@mobily/ts-belt": "^3.13.1",
-        "@trezor/env-utils": "1.2.1",
-        "@trezor/utils": "9.2.6"
-      },
-      "peerDependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/connect": {
-      "version": "9.4.7",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@babel/preset-typescript": "^7.24.7",
-        "@ethereumjs/common": "^4.4.0",
-        "@ethereumjs/tx": "^5.4.0",
-        "@fivebinaries/coin-selection": "2.2.1",
-        "@trezor/blockchain-link": "2.3.6",
-        "@trezor/blockchain-link-types": "1.2.5",
-        "@trezor/connect-analytics": "1.2.4",
-        "@trezor/connect-common": "0.2.7",
-        "@trezor/protobuf": "1.2.6",
-        "@trezor/protocol": "1.2.2",
-        "@trezor/schema-utils": "1.2.3",
-        "@trezor/transport": "1.3.7",
-        "@trezor/utils": "9.2.6",
-        "@trezor/utxo-lib": "2.2.6",
-        "blakejs": "^1.2.1",
-        "bs58": "^6.0.0",
-        "bs58check": "^4.0.0",
-        "cross-fetch": "^4.0.0"
-      },
-      "peerDependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/connect-analytics": {
-      "version": "1.2.4",
-      "license": "See LICENSE.md in repo root",
-      "dependencies": {
-        "@trezor/analytics": "1.2.5"
-      },
-      "peerDependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/connect-common": {
-      "version": "0.2.7",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@trezor/env-utils": "1.2.1",
-        "@trezor/utils": "9.2.6"
-      },
-      "peerDependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/connect-web": {
-      "version": "9.4.7",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@trezor/connect": "9.4.7",
-        "@trezor/connect-common": "0.2.7",
-        "@trezor/utils": "9.2.6"
-      },
-      "peerDependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/env-utils": {
-      "version": "1.2.1",
-      "license": "See LICENSE.md in repo root",
-      "dependencies": {
-        "ua-parser-js": "^1.0.37"
-      },
-      "peerDependencies": {
-        "expo-constants": "*",
-        "expo-localization": "*",
-        "react-native": "*",
-        "tslib": "^2.6.2"
-      },
-      "peerDependenciesMeta": {
-        "expo-constants": {
-          "optional": true
-        },
-        "expo-localization": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/protobuf": {
-      "version": "1.2.6",
-      "license": "See LICENSE.md in repo root",
-      "dependencies": {
-        "@trezor/schema-utils": "1.2.3",
-        "protobufjs": "7.4.0"
-      },
-      "peerDependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/schema-utils": {
-      "version": "1.2.3",
-      "license": "See LICENSE.md in repo root",
-      "dependencies": {
-        "@sinclair/typebox": "^0.33.7",
-        "ts-mixer": "^6.0.3"
-      },
-      "peerDependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/transport": {
-      "version": "1.3.7",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@trezor/protobuf": "1.2.6",
-        "@trezor/protocol": "1.2.2",
-        "@trezor/utils": "9.2.6",
-        "cross-fetch": "^4.0.0",
-        "long": "^4.0.0",
-        "protobufjs": "7.4.0",
-        "usb": "^2.14.0"
-      },
-      "peerDependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/utils": {
-      "version": "9.2.6",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "bignumber.js": "^9.1.2"
-      },
-      "peerDependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/utils/node_modules/bignumber.js": {
-      "version": "9.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "packages/caravan-wallets/node_modules/@trezor/utxo-lib": {
-      "version": "2.2.6",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@trezor/utils": "9.2.6",
-        "bchaddrjs": "^0.5.2",
-        "bech32": "^2.0.0",
-        "bip66": "^2.0.0",
-        "bitcoin-ops": "^1.4.1",
-        "blake-hash": "^2.0.0",
-        "blakejs": "^1.2.1",
-        "bn.js": "^5.2.1",
-        "bs58": "^6.0.0",
-        "bs58check": "^4.0.0",
-        "create-hmac": "^1.1.7",
-        "int64-buffer": "^1.0.1",
-        "pushdata-bitcoin": "^1.0.1",
-        "tiny-secp256k1": "^1.1.6",
-        "typeforce": "^1.18.0",
-        "varuint-bitcoin": "2.0.0",
-        "wif": "^5.0.0"
-      },
-      "peerDependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
     "packages/caravan-wallets/node_modules/@types/istanbul-reports": {
       "version": "1.1.2",
       "dev": true,
@@ -25402,10 +27310,6 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
-    },
-    "packages/caravan-wallets/node_modules/@types/web": {
-      "version": "0.0.174",
-      "license": "Apache-2.0"
     },
     "packages/caravan-wallets/node_modules/@types/yargs": {
       "version": "13.0.12",
@@ -25604,14 +27508,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "packages/caravan-wallets/node_modules/base-x": {
-      "version": "5.0.0",
-      "license": "MIT"
-    },
-    "packages/caravan-wallets/node_modules/bech32": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
     "packages/caravan-wallets/node_modules/bignumber.js": {
       "version": "8.1.1",
       "license": "MIT",
@@ -25619,17 +27515,9 @@
         "node": "*"
       }
     },
-    "packages/caravan-wallets/node_modules/bip66": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
     "packages/caravan-wallets/node_modules/bitbox-api": {
       "version": "0.7.0",
       "license": "Apache-2.0"
-    },
-    "packages/caravan-wallets/node_modules/bn.js": {
-      "version": "5.2.1",
-      "license": "MIT"
     },
     "packages/caravan-wallets/node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -25638,21 +27526,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "packages/caravan-wallets/node_modules/bs58": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^5.0.0"
-      }
-    },
-    "packages/caravan-wallets/node_modules/bs58check": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^1.2.0",
-        "bs58": "^6.0.0"
       }
     },
     "packages/caravan-wallets/node_modules/chalk": {
@@ -26024,13 +27897,6 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "packages/caravan-wallets/node_modules/node-addon-api": {
-      "version": "8.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
     "packages/caravan-wallets/node_modules/p-locate": {
       "version": "5.0.0",
       "dev": true,
@@ -26148,59 +28014,6 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "packages/caravan-wallets/node_modules/uint8array-tools": {
-      "version": "0.0.8",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "packages/caravan-wallets/node_modules/usb": {
-      "version": "2.14.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/w3c-web-usb": "^1.0.6",
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=12.22.0 <13.0 || >=14.17.0"
-      }
-    },
-    "packages/caravan-wallets/node_modules/varuint-bitcoin": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "uint8array-tools": "^0.0.8"
-      }
-    },
-    "packages/caravan-wallets/node_modules/wif": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "bs58check": "^4.0.0"
-      }
-    },
-    "packages/caravan-wallets/node_modules/ws": {
-      "version": "8.18.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "packages/caravan-wallets/node_modules/yallist": {
@@ -26998,12 +28811,7 @@
         "@caravan/bitcoin": "*",
         "@caravan/eslint-config": "*",
         "@caravan/typescript-config": "*",
-        "@types/jest": "^29.5.12",
         "esbuild-plugin-polyfill-node": "^0.3.0",
-        "jest": "^29.4.1",
-        "jsdom": "24.0.0",
-        "ts-jest": "^29.1.2",
-        "ts-node": "^10.9.2",
         "tsup": "^8.0.2",
         "typescript": "^5.4.5"
       },
@@ -27030,49 +28838,6 @@
       "version": "1.0.6",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/multisig/node_modules/@types/jest": {
-      "version": "29.5.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
-      }
-    },
-    "packages/multisig/node_modules/agent-base": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "packages/multisig/node_modules/cssstyle": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rrweb-cssom": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/multisig/node_modules/data-urls": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
     },
     "packages/multisig/node_modules/esbuild": {
       "version": "0.19.12",
@@ -27109,104 +28874,6 @@
         "@esbuild/win32-arm64": "0.19.12",
         "@esbuild/win32-ia32": "0.19.12",
         "@esbuild/win32-x64": "0.19.12"
-      }
-    },
-    "packages/multisig/node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-encoding": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/multisig/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "packages/multisig/node_modules/https-proxy-agent": {
-      "version": "7.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "packages/multisig/node_modules/jsdom": {
-      "version": "24.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssstyle": "^4.0.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.4.3",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^4.0.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.7",
-        "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.6.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.3",
-        "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0",
-        "ws": "^8.16.0",
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "canvas": "^2.11.2"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "packages/multisig/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "packages/multisig/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "packages/multisig/node_modules/rollup": {
@@ -27279,17 +28946,6 @@
         "webidl-conversions": "^4.0.2"
       }
     },
-    "packages/multisig/node_modules/tr46": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "packages/multisig/node_modules/tsup": {
       "version": "8.0.2",
       "dev": true,
@@ -27348,56 +29004,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "packages/multisig/node_modules/w3c-xmlserializer": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/multisig/node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/multisig/node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/multisig/node_modules/whatwg-url": {
-      "version": "14.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^5.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/multisig/node_modules/xml-name-validator": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "packages/typescript-config": {

--- a/packages/multisig/jest.config.js
+++ b/packages/multisig/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node"
-};

--- a/packages/multisig/package.json
+++ b/packages/multisig/package.json
@@ -28,21 +28,16 @@
     "dev": "npm run build -- --watch",
     "lint": "eslint src/",
     "ci": "npm run lint && npm run test",
-    "test": "jest src",
-    "test:watch": "jest --watch src",
-    "test:debug": "node --inspect-brk ../../node_modules/.bin/jest --runInBand"
+    "test": "vitest --watch=false src",
+    "test:watch": "vitest --watch src"
   },
   "devDependencies": {
     "@caravan/bitcoin": "*",
     "@caravan/eslint-config": "*",
     "@caravan/typescript-config": "*",
-    "@types/jest": "^29.5.12",
     "esbuild-plugin-polyfill-node": "^0.3.0",
-    "jest": "^29.4.1",
-    "jsdom": "24.0.0",
-    "ts-jest": "^29.1.2",
-    "ts-node": "^10.9.2",
     "tsup": "^8.0.2",
     "typescript": "^5.4.5"
   }
 }
+


### PR DESCRIPTION
# Migrate Multisig Package to Vitest

## Changes Made
- Removed Jest-related dependencies:
  - jest
  - ts-jest
  - jsdom
  - @types/jest
- Added Vitest dependency
- Updated test scripts in package.json:
  - Changed `test` to use `vitest --watch=false src`
  - Changed `test:watch` to use `vitest --watch src`
  - Removed `test:debug` as it's no longer needed

## Testing
- All 6 tests are passing with Vitest
<img width="856" alt="image" src="https://github.com/user-attachments/assets/44cb8114-ff5c-4d2b-a277-7fd7d00436ee" />

- No changes needed to test logic as it was already compatible with Vitest

## Impact
- Reduces package dependencies
- Aligns with project's move towards Vitest
- Simplifies test configuration
- Maintains existing test coverage and functionality

## Notes
- The migration was straightforward as the test file was already using modern test syntax
- No changes were needed to the test logic itself
- The package's minimal test dependencies made the migration process simpler

## Related
- Part of the ongoing effort to standardize on Vitest across the project #115 
- Similar to previous migrations of other packages