### PR TITLE
An admittedly hack-y fix for using @caravan/psbt on the server side.

### DIFF
--- a/.changeset/lucky-onions-promise.md
+++ b/.changeset/lucky-onions-promise.md
@@ -1,0 +1,5 @@
+---
+"@caravan/psbt": patch
+---
+
+Adds a fix for importing @caravan/psbt on the server side.

--- a/packages/caravan-psbt/provide-self.ts
+++ b/packages/caravan-psbt/provide-self.ts
@@ -16,7 +16,7 @@ if (typeof self === 'undefined') {
 const headerBytes = Uint8Array.from(Array.from(headerText, c => c.charCodeAt(0)))
 const n_header = headerBytes.length
 
-export default function ProvideSelf(): Plugin {
+export default function provideSelf(): Plugin {
   return {
     name: 'provide-self',
     setup(build) {

--- a/packages/caravan-psbt/provide-self.ts
+++ b/packages/caravan-psbt/provide-self.ts
@@ -1,0 +1,41 @@
+import { type Plugin } from 'esbuild'
+
+const headerText = `
+if (typeof self === 'undefined') {
+  var self;
+  if (typeof window !== 'undefined') {
+    self = window;
+  } else if (typeof globalThis !== 'undefined') {
+    self = globalThis;
+  } else {
+    self = {}
+  }
+}
+`
+
+const headerBytes = Uint8Array.from(Array.from(headerText, c => c.charCodeAt(0)))
+const n_header = headerBytes.length
+
+export default function ProvideSelf(): Plugin {
+  return {
+    name: 'provide-self',
+    setup(build) {
+      build.onEnd((result) => {
+        for (const file of result.outputFiles ?? []) {
+          if (file.path.endsWith('.js') || file.path.endsWith('.mjs')) {
+            const contentsIn = file.contents
+            const n_in = contentsIn.length
+            const contentsOut = new Uint8Array(n_in + headerBytes.length)
+            for (let i = 0; i < n_header; i++) {
+              contentsOut[i] = headerBytes[i]
+            }
+            for (let i = 0; i < n_in; i++) {
+              contentsOut[i + n_header] = contentsIn[i]
+            }
+            file.contents = contentsOut
+          }
+        }
+      })
+    }
+  }
+}

--- a/packages/caravan-psbt/tsup.config.ts
+++ b/packages/caravan-psbt/tsup.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "tsup";
 import { polyfillNode } from "esbuild-plugin-polyfill-node";
+import ProvideSelf from "./provide-self";
+
 
 export default defineConfig({
   esbuildPlugins: [
@@ -9,5 +11,6 @@ export default defineConfig({
         crypto: true,
       },
     }),
+    ProvideSelf(),
   ],
 });

--- a/packages/caravan-psbt/tsup.config.ts
+++ b/packages/caravan-psbt/tsup.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "tsup";
 import { polyfillNode } from "esbuild-plugin-polyfill-node";
-import ProvideSelf from "./provide-self";
+import provideSelf from "./provide-self";
 
 
 export default defineConfig({
@@ -11,6 +11,6 @@ export default defineConfig({
         crypto: true,
       },
     }),
-    ProvideSelf(),
+    provideSelf(),
   ],
 });


### PR DESCRIPTION
Adds an ESBuild plugin that prepends every JS build artifact with a slap dash declaration of self so that problematic but inconsequential browser only code doesn't break server side use.