### PR TITLE
Improve CI Pipeline to Run All Tests Across Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch: 
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push, pull_request]
+on: 
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   ci:
@@ -26,6 +30,8 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Run tests
+      - name: Run CI Tasks
         run: |
           npx turbo run ci
+        env:
+          NODE_ENV: test

--- a/turbo.json
+++ b/turbo.json
@@ -52,8 +52,9 @@
     },
     "ci": {
       "dependsOn": [
-        "^build"
-      ]
+        "^build", "build","test","lint"
+      ],
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
- This PR makes sure our CI pipeline runs all tests for every package in the monorepo.
- This should help catch issues across all packages before merging. 

using workflow_dispatch for testing in my own repo, will  remove this in the next commit after testing it