### PR TITLE
feat(wallets): policy from string conversion

### DIFF
--- a/.changeset/wise-ads-invent.md
+++ b/.changeset/wise-ads-invent.md
@@ -1,0 +1,5 @@
+---
+"@caravan/wallets": minor
+---
+
+Added from string policy conversion for KeyOrigins

--- a/packages/caravan-wallets/src/policy.test.ts
+++ b/packages/caravan-wallets/src/policy.test.ts
@@ -142,6 +142,41 @@ describe("KeyOrigin", () => {
       "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF"
     );
   });
+
+  describe("fromString", () => {
+    const testKeyOrigin =
+      "[76223a6e/48'/1'/0'/2']tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF";
+
+    it("can parse a key origin from a string", () => {
+      const keyOrigin = KeyOrigin.fromString(testKeyOrigin);
+      expect(keyOrigin.xfp).toEqual("76223a6e");
+      expect(keyOrigin.xfp).toEqual("76223a6e");
+      expect(keyOrigin.bip32Path).toEqual("m/48'/1'/0'/2'");
+      expect(keyOrigin.xpub).toEqual(
+        "tpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF"
+      );
+      expect(keyOrigin.network).toEqual(Network.TESTNET);
+      expect(keyOrigin.toString()).toEqual(testKeyOrigin);
+    });
+
+    it("throws an error if the key origin is invalid", () => {
+      expect(() => KeyOrigin.fromString("invalid")).toThrow();
+      expect(() =>
+        KeyOrigin.fromString(
+          "[76223a6e/48'/1'/0'/2']rpubDE7NQymr4AFtewpAsWtnreyq9ghkzQBXpCZjWLFVRAvnbf7vya2eMTvT2fPapNqL8SuVvLQdbUbMfWLVDCZKnsEBqp6UK93QEzL8Ck23AwF"
+        )
+      ).toThrow("Invalid key origin string");
+    });
+
+    it("can parse a key origin from a string with a network", () => {
+      const keyOrigin = KeyOrigin.fromString(testKeyOrigin, Network.REGTEST);
+      expect(keyOrigin.xfp).toEqual("76223a6e");
+      expect(keyOrigin.xfp).toEqual("76223a6e");
+      expect(keyOrigin.bip32Path).toEqual("m/48'/1'/0'/2'");
+      expect(keyOrigin.network).toEqual(Network.REGTEST);
+      expect(keyOrigin.toString()).toEqual(testKeyOrigin);
+    });
+  });
 });
 
 describe("getPolicyTemplateFromWalletConfig", () => {

--- a/packages/caravan-wallets/src/policy.ts
+++ b/packages/caravan-wallets/src/policy.ts
@@ -7,6 +7,8 @@ import {
   validateExtendedPublicKey,
   validateRootFingerprint,
   getMaskedDerivation,
+  Network,
+  validateExtendedPublicKeyForNetwork,
 } from "@caravan/bitcoin";
 import { WalletPolicy } from "ledger-bitcoin";
 import { BraidDetails, MultisigWalletConfig } from "@caravan/multisig";
@@ -17,6 +19,8 @@ export class KeyOrigin {
   readonly bip32Path: string;
 
   readonly xpub: string;
+
+  readonly network: Network;
 
   constructor({ xfp, bip32Path, xpub, network }) {
     // throws an error if not valid
@@ -32,6 +36,7 @@ export class KeyOrigin {
     const xpubError = validateExtendedPublicKey(xpub, network);
     if (xpubError) throw new Error(xpubError);
     this.xpub = xpub;
+    this.network = network;
   }
 
   /**
@@ -47,7 +52,35 @@ export class KeyOrigin {
     return `[${this.xfp}${path}]${this.xpub}`;
   }
 
-  // TODO: Needs a way to turn a serialized key origin to instance of class
+  static fromString(str: string, _network?: Network) {
+    let network = _network;
+    const match = str.match(
+      /^\[([0-9a-f]{8})((?:\/[0-9]+'?)+)\](((?:x|t)pub)[A-Za-z0-9]+)$/
+    );
+    if (!match) {
+      throw new Error("Invalid key origin string");
+    }
+    const xpub = match[3];
+    const prefix = match[3].slice(0, 4);
+
+    if (network) {
+      const error = validateExtendedPublicKeyForNetwork(xpub, network);
+      if (error) throw new Error(error);
+    } else if (!network && prefix === "xpub") {
+      network = Network.MAINNET;
+    } else if (!network && prefix === "tpub") {
+      network = Network.TESTNET;
+    } else {
+      throw new Error("Invalid network");
+    }
+
+    return new KeyOrigin({
+      xfp: match[1],
+      bip32Path: `m${match[2]}`,
+      xpub,
+      network,
+    });
+  }
 }
 
 export type MultisigScriptType = "sh" | "wsh" | "tr";


### PR DESCRIPTION
Small change to support converting a key origin descriptor string into a key origin object. 