### PR TITLE
Added contribution templates to streamline PRs and issue reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,52 @@
+name: Bug Report
+about: Report a bug to help us improve Caravan
+title: '[BUG] '
+labels: bug
+assignees: ''
+
+
+## Describe the Bug
+
+<!-- A clear and concise description of the bug. -->
+
+
+
+## Steps to Reproduce
+
+<!-- Steps to reproduce the behavior: -->
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+
+
+## Expected Behavior
+
+<!-- A clear description of what you expected to happen. -->
+
+
+
+## Actual Behavior
+
+<!-- What actually happened instead? -->
+
+
+
+## Screenshots / Videos
+
+<!-- If applicable, add screenshots or a screen recording to help explain the issue. -->
+
+
+
+## Environment
+
+- **Operating System**:
+- **Browser (if applicable)**:
+- **Version/Commit**:
+
+
+
+## Other Details / Additional Context
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,40 @@
+name: Feature Request
+about: Suggest a new feature or improvement for Caravan
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Describe the Feature
+
+<!-- A clear and concise description of the feature or improvement you’re proposing. -->
+
+
+
+## Why Is This Needed?
+
+<!-- Explain the problem this feature would solve or the benefit it would provide. -->
+
+
+
+## Suggested Solution or Implementation Ideas
+
+<!-- Share how you think this feature could be implemented, if you have any ideas. -->
+
+
+
+## Related Issues or References
+
+<!-- Link to any relevant issues, discussions, or external resources. -->
+
+
+
+## UI Mockups / Diagrams (if applicable)
+
+<!-- If it's a visual change, attach sketches, mockups, or diagrams. -->
+
+
+
+## Additional Context
+
+<!-- Add any other context or information here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -45,6 +45,6 @@ Fixes #<!--Add related issue number here.-->
 
 **Have you read the [contributing guide](https://github.com/caravan-bitcoin/caravan/blob/main/apps/coordinator/CONTRIBUTING.md)?**
 
-**For information on creating and using changesets, please refer to our [documentation on changesets](https://github.com/caravan-bitcoin/caravan?tab=readme-ov-file#changesets)**.
-
 <!--Yes or No-->
+
+**For information on creating and using changesets, please refer to our [documentation on changesets](https://github.com/caravan-bitcoin/caravan?tab=readme-ov-file#changesets)**.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,46 @@
+<!--
+Thank you for contributing to Caravan! Please provide the following details to help us review your pull request efficiently.
+-->
+
+**What kind of change does this PR introduce?**
+
+<!-- E.g. a bugfix, feature, refactoring, etc… -->
+
+**Issue Number:**
+
+Fixes #<!--Add related issue number here.-->
+
+**Snapshots/Videos:**
+
+<!--Add snapshots or videos wherever possible.-->
+
+**If relevant, did you update the documentation?**
+
+<!--Add link to Talawa-Docs.-->
+
+**Summary**
+
+<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
+<!-- Try to link to an open issue for more information. -->
+
+**Does this PR introduce a breaking change?**
+
+<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
+
+## Checklist
+- [ ] I have tested my changes thoroughly.
+- [ ] I have added or updated tests to cover my changes (if applicable).
+- [ ] I have verified that test coverage meets or exceeds 95% (if applicable).
+- [ ] I have run the test suite locally, and all tests pass.
+- [ ] I have written tests for all new changes/features
+- [ ] I have followed the project's coding style and conventions.
+
+
+
+**Other information**
+
+<!--Add extra information about this PR here-->
+
+**Have you read the [contributing guide](https://github.com/caravan-bitcoin/caravan/blob/main/apps/coordinator/CONTRIBUTING.md)?**
+
+<!--Yes or No-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,6 +34,8 @@ Fixes #<!--Add related issue number here.-->
 - [ ] I have run the test suite locally, and all tests pass.
 - [ ] I have written tests for all new changes/features
 - [ ] I have followed the project's coding style and conventions.
+- [ ] I have created a changeset to document my changes (`` npm run changeset ``)
+
 
 
 
@@ -42,5 +44,7 @@ Fixes #<!--Add related issue number here.-->
 <!--Add extra information about this PR here-->
 
 **Have you read the [contributing guide](https://github.com/caravan-bitcoin/caravan/blob/main/apps/coordinator/CONTRIBUTING.md)?**
+
+**For information on creating and using changesets, please refer to our [documentation on changesets](https://github.com/caravan-bitcoin/caravan?tab=readme-ov-file#changesets)**.
 
 <!--Yes or No-->


### PR DESCRIPTION
Hi, I’ve added a ``PULL_REQUEST_TEMPLATE.md`` file to the  ``.github`` directory to help standardize pull request submissions and make the contribution process smoother for everyone. The template includes sections for change type, issue number, snapshots, documentation updates, and a checklist to ensure high-quality PRs.

**Why this could be helpful:**
The template will guide contributors to provide essential details like the type of change, related issues, media evidence (screenshots/videos), documentation updates, and testing status, making it easier for maintainers to review and merge changes efficiently.

Please review and let me know any feedback or suggestions,  I'm happy to make adjustments as needed