### PR TITLE
Import Partially Signed PSBT works now 

### DIFF
--- a/.changeset/long-chicken-lie.md
+++ b/.changeset/long-chicken-lie.md
@@ -1,0 +1,5 @@
+---
+"caravan-coordinator": patch
+---
+
+Import Partially Signed PSBT works now

--- a/apps/coordinator/src/actions/transactionActions.js
+++ b/apps/coordinator/src/actions/transactionActions.js
@@ -418,7 +418,6 @@ export function importPSBT(psbtText) {
       // ==== Extract and import signatures ====
       try {
         const signatureSets = extractSignaturesFromPSBT(psbt, inputs);
-
         if (signatureSets.length > 0) {
           // Map signatures to Caravan's signature importers
           const importerData = mapSignaturesToImporters(signatureSets);

--- a/apps/coordinator/src/actions/transactionActions.js
+++ b/apps/coordinator/src/actions/transactionActions.js
@@ -388,8 +388,7 @@ export function setSignaturesFromPsbt(psbt) {
         // Transform raw signature data into Caravan's signature importer format
         // This maps each signature set to an "importer" (numbered 1, 2, 3...)
         // that corresponds to Caravan's UI signature input slots
-        const state = getState();
-        const importerData = mapSignaturesToImporters(state, signatureSets);
+        const importerData = mapSignaturesToImporters(signatureSets);
 
         // === STEP 3: Update Redux state for each signature set ===
         // For each complete signature set, we need to update multiple parts

--- a/apps/coordinator/src/actions/transactionActions.js
+++ b/apps/coordinator/src/actions/transactionActions.js
@@ -6,8 +6,8 @@ import {
 import { getSpendableSlices, getConfirmedBalance } from "../selectors/wallet";
 import {
   selectInputsFromPSBT,
-  mapSignaturesToImporters,
-  extractSignaturesFromPSBT,
+  selectSignaturesFromPSBT,
+  selectSignaturesForImporters,
 } from "../selectors/transaction";
 import {
   setSignatureImporterSignature,
@@ -380,13 +380,13 @@ export function setSignaturesFromPsbt(psbt) {
     // - Parse partial signatures from PSBT data
     // - Group signatures by signer (one signer signs ALL inputs)
     const state = getState();
-    const signatureSets = extractSignaturesFromPSBT(state, psbt);
+    const signatureSets = selectSignaturesFromPSBT(state, psbt);
     // === STEP 2: Process signatures if any were found ===
     if (signatureSets.length > 0) {
       // Transform raw signature data into Caravan's signature importer format
       // This maps each signature set to an "importer" (numbered 1, 2, 3...)
       // that corresponds to Caravan's UI signature input slots
-      const importerData = mapSignaturesToImporters(signatureSets);
+      const importerData = selectSignaturesForImporters(state, psbt);
       // === STEP 3: Update Redux state for each signature set ===
       // For each complete signature set, we need to update multiple parts
       // of the signature importer state. This is Caravan's pattern for

--- a/apps/coordinator/src/components/Wallet/TransactionPreview.jsx
+++ b/apps/coordinator/src/components/Wallet/TransactionPreview.jsx
@@ -91,7 +91,7 @@ const SignatureStatus = () => {
     needsSignatures,
   } = useSigningState();
 
-  // We Don't render anything if no signatures are present
+  // We don't render anything if no signatures are present
   if (signedCount === 0) {
     return null;
   }
@@ -123,17 +123,17 @@ const SignatureStatus = () => {
           variant={isFullySigned ? "filled" : "outlined"}
         />
         {isFullySigned && (
-          <Chip label="Fully Signed" color="success" size="small" />
+          <Chip label="Fully signed" color="success" size="small" />
         )}
         {hasPartialSignatures && (
-          <Chip label="Partially Signed" color="warning" size="small" />
+          <Chip label="Partially signed" color="warning" size="small" />
         )}
       </Box>
 
       {/* Status-specific alerts */}
       {hasPartialSignatures && (
         <Alert severity="info" sx={{ mb: 1 }}>
-          <AlertTitle>Partial Signatures Detected</AlertTitle>
+          <AlertTitle>Partial signatures detected</AlertTitle>
           This transaction has {signedCount} out of {requiredSigners} required
           signatures. You need {needsSignatures} more signature
           {needsSignatures > 1 ? "s" : ""} to broadcast.
@@ -142,7 +142,7 @@ const SignatureStatus = () => {
 
       {isFullySigned && (
         <Alert severity="success" sx={{ mb: 1 }}>
-          <AlertTitle>Transaction Ready</AlertTitle>
+          <AlertTitle>Transaction ready</AlertTitle>
           This transaction has all {requiredSigners} required signatures and is
           ready to broadcast.
         </Alert>
@@ -151,7 +151,7 @@ const SignatureStatus = () => {
       {/* Warning about editing clearing signatures */}
       {signedCount > 0 && (
         <Alert severity="warning" icon={<EditIcon />}>
-          <AlertTitle>Important: Editing Will Clear Signatures</AlertTitle>
+          <AlertTitle>Important: Editing will clear signatures</AlertTitle>
           If you edit this transaction (inputs, outputs, or fee), all existing
           signatures will be cleared and you&apos;ll need to collect signatures
           again from all signers.

--- a/apps/coordinator/src/components/Wallet/WalletSpend.jsx
+++ b/apps/coordinator/src/components/Wallet/WalletSpend.jsx
@@ -142,7 +142,19 @@ class WalletSpend extends React.Component {
       importPSBTError: errorMessage,
     });
   };
-
+  // Helper function to detect if content is binary PSBT
+  isBinaryPSBT = (arrayBuffer) => {
+    const uint8Array = new Uint8Array(arrayBuffer);
+    // Check for binary PSBT magic bytes (0x70736274ff)
+    return (
+      uint8Array.length >= 5 &&
+      uint8Array[0] === 0x70 &&
+      uint8Array[1] === 0x73 &&
+      uint8Array[2] === 0x62 &&
+      uint8Array[3] === 0x74 &&
+      uint8Array[4] === 0xff
+    );
+  };
   handleImportPSBT = ({ target }) => {
     const { importPSBT } = this.props;
 
@@ -157,18 +169,55 @@ class WalletSpend extends React.Component {
         this.setPSBTToggleAndError(false, "Multiple PSBTs provided.");
         return;
       }
-
+      const file = target.files[0];
       const fileReader = new FileReader();
       fileReader.onload = (event) => {
         try {
-          const psbtText = event.target.result;
-          importPSBT(psbtText);
+          const arrayBuffer = event.target.result;
+
+          if (this.isBinaryPSBT(arrayBuffer)) {
+            // For binary PSBT, try Uint8Array first, fallback to base64 if needed
+            try {
+              const uint8Array = new Uint8Array(arrayBuffer);
+              importPSBT(uint8Array);
+            } catch (bufferError) {
+              // If direct binary fails, convert to base64
+              console.warn(
+                "Direct binary import failed, trying base64:",
+                bufferError.message,
+              );
+              const uint8Array = new Uint8Array(arrayBuffer);
+              let binaryString = "";
+              for (let i = 0; i < uint8Array.length; i++) {
+                binaryString += String.fromCharCode(uint8Array[i]);
+              }
+              const base64String = btoa(binaryString);
+              importPSBT(base64String);
+            }
+          } else {
+            // Handle text PSBT
+            const textDecoder = new TextDecoder("utf-8");
+            const textContent = textDecoder.decode(arrayBuffer).trim();
+
+            if (!textContent) {
+              this.setPSBTToggleAndError(false, "Invalid or empty PSBT file.");
+              return;
+            }
+
+            importPSBT(textContent);
+          }
+
           this.setPSBTToggleAndError(false, "");
         } catch (e) {
           this.setPSBTToggleAndError(false, e.message);
         }
       };
-      fileReader.readAsText(target.files[0]);
+
+      fileReader.onerror = () => {
+        this.setPSBTToggleAndError(false, "Error reading file.");
+      };
+
+      fileReader.readAsArrayBuffer(file);
     } catch (e) {
       this.setPSBTToggleAndError(false, e.message);
     }
@@ -238,7 +287,7 @@ class WalletSpend extends React.Component {
                       style={{ display: "none" }}
                       id="import-psbt"
                       name="import-psbt"
-                      accept="application/base64"
+                      accept=".psbt,*/*"
                       onChange={this.handleImportPSBT}
                       type="file"
                     />

--- a/apps/coordinator/src/selectors/transaction.ts
+++ b/apps/coordinator/src/selectors/transaction.ts
@@ -23,6 +23,12 @@ export const selectInputsFromPSBT = createSelector(
 
     const inputIdentifiers = new Set(
       psbt.txInputs.map((input) => {
+        /*
+         * All input TXIDs are expected to be in **big-endian**
+         * format (human-readable format). Which we get from block explorers, wallets, APIs
+         * But PSBTs will need txid to be in little-endian format to ensure compatibility with Bitcoin's
+         * internal data structures and processing so here we convert the txid to little-endian format
+         */
         const txid = reverseBuffer(input.hash).toString("hex");
         return createInputIdentifier(txid, input.index);
       }),

--- a/apps/coordinator/src/selectors/transaction.ts
+++ b/apps/coordinator/src/selectors/transaction.ts
@@ -1,0 +1,39 @@
+import { reverseBuffer } from "bitcoinjs-lib/src/bufferutils";
+import { Psbt } from "bitcoinjs-lib-v6";
+import { createSelector } from "reselect";
+import { getSpendableSlices } from "./wallet";
+import { UTXO, Input, Slice } from "utils/psbtUtils";
+
+/**
+ * Processes inputs from PSBT and matches them with wallet UTXOs.
+ */
+export const selectInputsFromPSBT = (psbt: Psbt) =>
+  createSelector([getSpendableSlices], (slices: any) => {
+    const createInputIdentifier = (txid: string, index: number) =>
+      `${txid}:${index}`;
+
+    const inputIdentifiers = new Set(
+      psbt.txInputs.map((input) => {
+        const txid = reverseBuffer(input.hash).toString("hex");
+        return createInputIdentifier(txid, input.index);
+      }),
+    );
+
+    const inputs: Input[] = [];
+    slices.forEach((slice: Slice & { utxos: UTXO }) => {
+      Object.entries(slice.utxos).forEach(([, utxo]) => {
+        const inputIdentifier = createInputIdentifier(utxo.txid, utxo.index);
+        if (inputIdentifiers.has(inputIdentifier)) {
+          const input = {
+            ...utxo,
+            multisig: slice.multisig,
+            bip32Path: slice.bip32Path,
+            change: slice.change,
+          };
+          inputs.push(input);
+        }
+      });
+    });
+
+    return inputs;
+  });

--- a/apps/coordinator/src/selectors/transaction.ts
+++ b/apps/coordinator/src/selectors/transaction.ts
@@ -7,8 +7,9 @@ import { UTXO, Input, Slice } from "utils/psbtUtils";
 /**
  * Processes inputs from PSBT and matches them with wallet UTXOs.
  */
-export const selectInputsFromPSBT = (psbt: Psbt) =>
-  createSelector([getSpendableSlices], (slices: any) => {
+export const selectInputsFromPSBT = createSelector(
+  [getSpendableSlices, (state: any, psbt: Psbt) => psbt],
+  (slices: any, psbt: Psbt) => {
     const createInputIdentifier = (txid: string, index: number) =>
       `${txid}:${index}`;
 
@@ -36,4 +37,5 @@ export const selectInputsFromPSBT = (psbt: Psbt) =>
     });
 
     return inputs;
-  });
+  },
+);

--- a/apps/coordinator/src/selectors/transaction.ts
+++ b/apps/coordinator/src/selectors/transaction.ts
@@ -1,8 +1,15 @@
 import { reverseBuffer } from "bitcoinjs-lib/src/bufferutils";
 import { Psbt } from "bitcoinjs-lib-v6";
 import { createSelector } from "reselect";
+import { validateMultisigPsbtSignature } from "@caravan/psbt";
 import { getSpendableSlices } from "./wallet";
-import { UTXO, Input, Slice } from "utils/psbtUtils";
+import {
+  UTXO,
+  Input,
+  Slice,
+  SignatureInfo,
+  SignatureSet,
+} from "utils/psbtUtils";
 
 /**
  * Processes inputs from PSBT and matches them with wallet UTXOs.
@@ -39,3 +46,199 @@ export const selectInputsFromPSBT = createSelector(
     return inputs;
   },
 );
+
+/**
+ * Maps extracted signature sets to Caravan's signature importer format.
+ *
+ * @param signatureSets - Signature sets from extractSignaturesFromPSBT
+ * @returns Array formatted for Caravan's signature importers
+ */
+export const mapSignaturesToImporters = (
+  state: any, // eslint-disable-line @typescript-eslint/no-unused-vars
+  signatureSets: SignatureSet[],
+) => {
+  return signatureSets.map((sigSet, index) => ({
+    importerNumber: index + 1, // As in Caravan we use 1-based indexing
+    signatures: sigSet.signatures,
+    publicKeys: sigSet.publicKeys,
+    signerPubkey: sigSet.signerPubkey,
+    finalized: true, // Mark as complete since we have all signatures
+  }));
+};
+
+/**
+ * Extracts signatures from a PSBT and organizes them by signer.
+ *
+ * @param  psbt - The PSBT object
+ * @param  inputs - Array of input objects with multisig info
+ * @param  outputs - Array of output objects
+ * @param  network - Network (mainnet, testnet, etc.)
+ * @returns  Array of signature sets, each containing signatures for all inputs
+ */
+export const extractSignaturesFromPSBT = (
+  state: any, // eslint-disable-line @typescript-eslint/no-unused-vars
+  psbt: Psbt,
+) => {
+  // Get Inputs to extract Signature from
+  const inputs = selectInputsFromPSBT(state, psbt);
+
+  // Get all partial signatures from the PSBT
+  // Each input in a PSBT can have multiple partial signatures (one per signer)
+  const inputSignatures: SignatureInfo[][] = [];
+
+  for (let inputIndex = 0; inputIndex < psbt.data.inputs.length; inputIndex++) {
+    const input = psbt.data.inputs[inputIndex];
+    const inputSigs: SignatureInfo[] = [];
+
+    // So now , we Extract partial signatures from this input
+    // As partialSig is an array of {pubkey: Buffer, signature: Buffer
+    if (input.partialSig && input.partialSig.length > 0) {
+      for (const partialSig of input.partialSig) {
+        inputSigs.push({
+          signature: partialSig.signature.toString("hex"),
+          pubkey: partialSig.pubkey.toString("hex"),
+          inputIndex,
+        });
+      }
+    }
+
+    inputSignatures.push(inputSigs);
+  }
+
+  // Now we need to group signatures by signer
+  // In a multisig, each signer signs ALL inputs with the same key
+  // So we group signatures that use the same public key across all inputs
+  const signatureSets = groupSignaturesBySigner(psbt, inputSignatures, inputs);
+  return signatureSets;
+};
+
+/**
+ * Groups signatures by signer (same pubkey across all inputs = same signer).
+ *
+ * *Note* not a selector a plain util function
+ *
+ * @param  psbt - The PSBT object
+ * @param  inputSignatures - Signatures organized by input
+ * @param  inputs - Input objects for validation
+ * @returns  Array of signature sets
+ */
+function groupSignaturesBySigner(
+  psbt: Psbt,
+  inputSignatures: SignatureInfo[][],
+  inputs: Input[],
+): SignatureSet[] {
+  // Find all unique public keys across all inputs
+  const allPubkeys = new Set<string>();
+  inputSignatures.forEach((inputSigs) => {
+    inputSigs.forEach((sig) => allPubkeys.add(sig.pubkey));
+  });
+
+  const signatureSets: SignatureSet[] = [];
+
+  // For each unique pubkey, try to build a complete signature set
+  for (const pubkey of allPubkeys) {
+    const signatureSet: string[] = [];
+    const publicKeySet: string[] = [];
+    let isCompleteSet = true;
+
+    // Check if this pubkey has signed ALL inputs
+    for (let inputIndex = 0; inputIndex < inputs.length; inputIndex++) {
+      const inputSigs = inputSignatures[inputIndex];
+      const sigForThisPubkey = inputSigs.find((sig) => sig.pubkey === pubkey);
+
+      if (sigForThisPubkey) {
+        // Validate this signature to make sure it's correct
+        try {
+          const validatedPubkey = validateSignatureForInput(
+            sigForThisPubkey.signature as Buffer,
+            inputIndex,
+            psbt,
+            inputs,
+          );
+
+          if (validatedPubkey) {
+            signatureSet.push(sigForThisPubkey.signature as string);
+            publicKeySet.push(validatedPubkey);
+          } else {
+            console.warn(
+              `❌ Invalid signature for input ${inputIndex}, pubkey ${pubkey}`,
+            );
+            isCompleteSet = false;
+            break;
+          }
+        } catch (error) {
+          console.warn(
+            `❌ Error validating signature for input ${inputIndex}:`,
+            error.message,
+          );
+          isCompleteSet = false;
+          break;
+        }
+      } else {
+        // This pubkey didn't sign this input, so it's not a complete set
+        isCompleteSet = false;
+        break;
+      }
+    }
+
+    // Only add complete signature sets (where one signer signed ALL inputs)
+    if (isCompleteSet && signatureSet.length === inputs.length) {
+      signatureSets.push({
+        signatures: signatureSet,
+        publicKeys: publicKeySet,
+        signerPubkey: pubkey,
+      });
+    }
+  }
+
+  return signatureSets;
+}
+
+/**
+ * Validates a signature for a specific input.
+ *
+ * *Note* not a selector a plain util function
+ *
+ * @param signature - Hex-encoded signature
+ * @param inputIndex - Index of the input being signed
+ * @param originalPsbt - The original PSBT object we already have
+ * @param inputs - All transaction inputs (for amountSats)
+ * @returns The public key if valid, false if invalid
+ */
+function validateSignatureForInput(
+  signature: Buffer,
+  inputIndex: number,
+  originalPsbt: Psbt,
+  inputs: Input[],
+): string | false {
+  try {
+    //  Handle empty signatures
+    if (!signature || signature.length === 0) {
+      return false;
+    }
+
+    const validatedPubkey = validateMultisigPsbtSignature(
+      originalPsbt.toBase64(),
+      inputIndex,
+      signature,
+      inputs[inputIndex].amountSats,
+    );
+
+    // Handle the case where validateMultisigPsbtSignature returns boolean true
+    // Convert true to false since we only want string (pubkey) or false
+    if (validatedPubkey === true) {
+      console.warn(
+        `Signature validation returned true but expected pubkey string for input ${inputIndex}`,
+      );
+      return false;
+    }
+    // Return the pubkey string or false
+    return validatedPubkey;
+  } catch (error) {
+    console.error(
+      `❌ Signature validation failed for input ${inputIndex + 1}:`,
+      error.message,
+    );
+    return false;
+  }
+}

--- a/apps/coordinator/src/selectors/transaction.ts
+++ b/apps/coordinator/src/selectors/transaction.ts
@@ -185,13 +185,7 @@ export const selectInputsFromPSBT = createSelector(
  */
 export const selectSignaturesFromPSBT = createSelector(
   [selectInputsFromPSBT, (state: any, psbt: Psbt) => psbt],
-  (inputs, psbt) => {
-    console.log(
-      "extractSignaturesFromPSBT",
-      extractSignaturesFromPSBT(psbt, inputs),
-    );
-    return extractSignaturesFromPSBT(psbt, inputs);
-  },
+  (inputs, psbt) => extractSignaturesFromPSBT(psbt, inputs),
 );
 
 /**

--- a/apps/coordinator/src/utils/psbtUtils.ts
+++ b/apps/coordinator/src/utils/psbtUtils.ts
@@ -54,10 +54,10 @@ export interface SignatureInfo {
   derivedPubkey: string; // The actual derived pubkey for this input
 }
 
-export /**
+/**
  * Interface for signer identification across multiple inputs
  */
-interface SignerIdentity {
+export interface SignerIdentity {
   signerIndex: number; // Position in the multisig setup (0, 1, 2, etc.)
   masterFingerprint?: string; // Master key fingerprint if available
   signatures: Buffer[] | string[]; // Signatures for each input (in order)

--- a/apps/coordinator/src/utils/psbtUtils.ts
+++ b/apps/coordinator/src/utils/psbtUtils.ts
@@ -1,0 +1,309 @@
+import { networkData, Network } from "@caravan/bitcoin";
+import {
+  getPsbtVersionNumber,
+  PsbtV2,
+  autoLoadPSBT as psbtPackageAutoLoad,
+  validateMultisigPsbtSignature,
+} from "@caravan/psbt";
+import { Psbt } from "bitcoinjs-lib-v6";
+
+/**
+ * Interface for UTXO data structure (This one is how utxo's are stored in Redux)
+ *  TO-DO: Make all the various UTXO types we have in @caravan/client and @caravan/fees in sync
+ */
+interface UTXO {
+  confirmed: boolean;
+  txid: string;
+  index: number;
+  amount: string;
+  amountSats: string;
+  transactionHex: string;
+  time: number;
+  change: boolean;
+  spend: boolean;
+  fetchedUTXOs: boolean;
+  fetchUTXOsError: string;
+  addressUsed: boolean;
+  addressKnown: boolean;
+}
+
+/**
+ * Interface for slice data structure
+ */
+interface Slice {
+  multisig: any; // Type this more specifically based on our multisig structure
+  bip32Path: string;
+  change: boolean;
+}
+
+/**
+ * Interface for input objects with multisig information
+ */
+interface Input extends UTXO {
+  multisig: Slice["multisig"]; // From slice.multisig
+  bip32Path: Slice["bip32Path"]; // From slice.bip32Path
+}
+
+/**
+ * Interface for signature information extracted from PSBT
+ */
+interface SignatureInfo {
+  signature: Buffer;
+  pubkey: string;
+  inputIndex: number;
+}
+
+/**
+ * Interface for signature sets grouped by signer
+ */
+interface SignatureSet {
+  signatures: Buffer[];
+  publicKeys: string[];
+  signerPubkey: string;
+}
+
+/**
+ * Loads a PSBT from a string or buffer, handling both PSBTv0 and PSBTv2 formats.
+ * Uses only functionality from the @caravan/psbt package removing dependency on the outdated use of @caravan/bitcoin
+ *
+ * @param psbtText - The PSBT as a string or buffer
+ * @param network - The Bitcoin network (mainnet, testnet, etc.)
+ * @returns The PSBT object compatible with bitcoinjs-lib
+ * @throws Error if the PSBT cannot be parsed
+ */
+export function loadPsbt(
+  psbtText: string | Buffer,
+  network: Network,
+): Psbt | null {
+  const options = { network: networkData(network) };
+
+  try {
+    // Try to determine the PSBT version
+    const version = getPsbtVersionNumber(psbtText);
+
+    if (version >= 2) {
+      // It's a PSBTv2, convert it to PSBTv0 format for compatibility
+      console.log(
+        `Detected PSBTv2 (version ${version}), converting to PSBTv0 format`,
+      );
+      try {
+        const psbtv2 = new PsbtV2(psbtText, true); // Allow version 1 transactions if needed
+        const psbtv0Base64 = psbtv2.toV0("base64");
+        // Use the autoLoadPSBT from @caravan/psbt
+        return psbtPackageAutoLoad(psbtv0Base64, options);
+      } catch (e) {
+        console.error("Failed to parse PSBTv2:", e);
+        throw new Error(`Failed to parse PSBTv2: ${e.message}`);
+      }
+    } else {
+      // It's a PSBTv0, use the autoLoadPSBT from @caravan/psbt
+      const psbt = psbtPackageAutoLoad(psbtText, options);
+      if (!psbt) {
+        throw new Error("Could not parse PSBT. Invalid format.");
+      }
+      return psbt;
+    }
+  } catch (e) {
+    console.error("Error loading PSBT:", e);
+    throw new Error(`Error loading PSBT: ${e.message}`);
+  }
+}
+
+/**
+ * Extracts signatures from a PSBT and organizes them by signer.
+ *
+ * @param  psbt - The PSBT object
+ * @param  inputs - Array of input objects with multisig info
+ * @param  outputs - Array of output objects
+ * @param  network - Network (mainnet, testnet, etc.)
+ * @returns  Array of signature sets, each containing signatures for all inputs
+ */
+export function extractSignaturesFromPSBT(psbt: Psbt, inputs: Input[]) {
+  // Get all partial signatures from the PSBT
+  // Each input in a PSBT can have multiple partial signatures (one per signer)
+  const inputSignatures: SignatureInfo[][] = [];
+
+  for (let inputIndex = 0; inputIndex < psbt.data.inputs.length; inputIndex++) {
+    const input = psbt.data.inputs[inputIndex];
+    const inputSigs: SignatureInfo[] = [];
+
+    // So now , we Extract partial signatures from this input
+    // As partialSig is an array of {pubkey: Buffer, signature: Buffer
+    if (input.partialSig && input.partialSig.length > 0) {
+      for (const partialSig of input.partialSig) {
+        inputSigs.push({
+          signature: partialSig.signature,
+          pubkey: partialSig.pubkey.toString("hex"),
+          inputIndex,
+        });
+      }
+    }
+
+    inputSignatures.push(inputSigs);
+  }
+
+  // Now we need to group signatures by signer
+  // In a multisig, each signer signs ALL inputs with the same key
+  // So we group signatures that use the same public key across all inputs
+  const signatureSets = groupSignaturesBySigner(psbt, inputSignatures, inputs);
+  return signatureSets;
+}
+
+/**
+ * Groups signatures by signer (same pubkey across all inputs = same signer).
+ *
+ * @param  psbt - The PSBT object
+ * @param  inputSignatures - Signatures organized by input
+ * @param  inputs - Input objects for validation
+ * @returns  Array of signature sets
+ */
+function groupSignaturesBySigner(
+  psbt: Psbt,
+  inputSignatures: SignatureInfo[][],
+  inputs: Input[],
+): SignatureSet[] {
+  // Find all unique public keys across all inputs
+  const allPubkeys = new Set<string>();
+  inputSignatures.forEach((inputSigs) => {
+    inputSigs.forEach((sig) => allPubkeys.add(sig.pubkey));
+  });
+
+  const signatureSets: SignatureSet[] = [];
+
+  // For each unique pubkey, try to build a complete signature set
+  for (const pubkey of allPubkeys) {
+    const signatureSet: Buffer[] = [];
+    const publicKeySet: string[] = [];
+    let isCompleteSet = true;
+
+    // Check if this pubkey has signed ALL inputs
+    for (let inputIndex = 0; inputIndex < inputs.length; inputIndex++) {
+      const inputSigs = inputSignatures[inputIndex];
+      const sigForThisPubkey = inputSigs.find((sig) => sig.pubkey === pubkey);
+
+      if (sigForThisPubkey) {
+        // Validate this signature to make sure it's correct
+        try {
+          const validatedPubkey = validateSignatureForInput(
+            sigForThisPubkey.signature,
+            inputIndex,
+            psbt,
+            inputs,
+          );
+
+          if (validatedPubkey) {
+            signatureSet.push(sigForThisPubkey.signature);
+            publicKeySet.push(validatedPubkey);
+          } else {
+            console.warn(
+              `❌ Invalid signature for input ${inputIndex}, pubkey ${pubkey}`,
+            );
+            isCompleteSet = false;
+            break;
+          }
+        } catch (error) {
+          console.warn(
+            `❌ Error validating signature for input ${inputIndex}:`,
+            error.message,
+          );
+          isCompleteSet = false;
+          break;
+        }
+      } else {
+        // This pubkey didn't sign this input, so it's not a complete set
+        isCompleteSet = false;
+        break;
+      }
+    }
+
+    // Only add complete signature sets (where one signer signed ALL inputs)
+    if (isCompleteSet && signatureSet.length === inputs.length) {
+      signatureSets.push({
+        signatures: signatureSet,
+        publicKeys: publicKeySet,
+        signerPubkey: pubkey,
+      });
+    }
+  }
+
+  return signatureSets;
+}
+
+/**
+ * Validates a signature for a specific input.
+ *
+ * @param signature - Hex-encoded signature
+ * @param inputIndex - Index of the input being signed
+ * @param originalPsbt - The original PSBT object we already have
+ * @param inputs - All transaction inputs (for amountSats)
+ * @returns The public key if valid, false if invalid
+ */
+function validateSignatureForInput(
+  signature: Buffer,
+  inputIndex: number,
+  originalPsbt: Psbt,
+  inputs: Input[],
+): string | false {
+  try {
+    //  Handle empty signatures
+    if (!signature || signature.length === 0) {
+      return false;
+    }
+
+    const validatedPubkey = validateMultisigPsbtSignature(
+      originalPsbt.toBase64(),
+      inputIndex,
+      signature,
+      inputs[inputIndex].amountSats,
+    );
+
+    // Handle the case where validateMultisigPsbtSignature returns boolean true
+    // Convert true to false since we only want string (pubkey) or false
+    if (validatedPubkey === true) {
+      console.warn(
+        `Signature validation returned true but expected pubkey string for input ${inputIndex}`,
+      );
+      return false;
+    }
+    // Return the pubkey string or false
+    return validatedPubkey;
+  } catch (error) {
+    console.error(
+      `❌ Signature validation failed for input ${inputIndex + 1}:`,
+      error.message,
+    );
+    return false;
+  }
+}
+
+/**
+ * Maps extracted signature sets to Caravan's signature importer format.
+ *
+ * @param signatureSets - Signature sets from extractSignaturesFromPSBT
+ * @returns Array formatted for Caravan's signature importers
+ */
+export function mapSignaturesToImporters(signatureSets: SignatureSet[]) {
+  return signatureSets.map((sigSet, index) => ({
+    importerNumber: index + 1, // As in Caravan we use 1-based indexing
+    signatures: sigSet.signatures,
+    publicKeys: sigSet.publicKeys,
+    signerPubkey: sigSet.signerPubkey,
+    finalized: true, // Mark as complete since we have all signatures
+  }));
+}
+
+/**
+ * Determines if a PSBT string/buffer is likely a PSBTv2.
+ * This is a quick check without full parsing.
+ *
+ * @param {string|Buffer} psbtText - The PSBT data
+ * @returns {boolean} True if likely PSBTv2, false otherwise
+ */
+export function isPsbtV2(psbtText: string | Buffer): boolean {
+  try {
+    const version = getPsbtVersionNumber(psbtText);
+    return version >= 2;
+  } catch {
+    return false;
+  }
+}

--- a/apps/coordinator/src/utils/psbtUtils.ts
+++ b/apps/coordinator/src/utils/psbtUtils.ts
@@ -80,28 +80,18 @@ export function loadPsbt(
     // Try to determine the PSBT version
     const version = getPsbtVersionNumber(psbtText);
 
-    if (version >= 2) {
-      // It's a PSBTv2, convert it to PSBTv0 format for compatibility
-      console.log(
-        `Detected PSBTv2 (version ${version}), converting to PSBTv0 format`,
-      );
-      try {
-        const psbtv2 = new PsbtV2(psbtText, true); // Allow version 1 transactions if needed
-        const psbtv0Base64 = psbtv2.toV0("base64");
-        // Use the autoLoadPSBT from @caravan/psbt
-        return psbtPackageAutoLoad(psbtv0Base64, options);
-      } catch (e) {
-        console.error("Failed to parse PSBTv2:", e);
-        throw new Error(`Failed to parse PSBTv2: ${e.message}`);
-      }
-    } else {
-      // It's a PSBTv0, use the autoLoadPSBT from @caravan/psbt
-      const psbt = psbtPackageAutoLoad(psbtText, options);
-      if (!psbt) {
-        throw new Error("Could not parse PSBT. Invalid format.");
-      }
-      return psbt;
+    if (version === 2) {
+      const psbtv2 = new PsbtV2(psbtText, true); // Allow version 1 transactions if needed
+      const psbtv0Base64 = psbtv2.toV0("base64");
+      // Use the autoLoadPSBT from @caravan/psbt
+      return psbtPackageAutoLoad(psbtv0Base64, options);
     }
+    // It's a PSBTv0, use the autoLoadPSBT from @caravan/psbt
+    const psbt = psbtPackageAutoLoad(psbtText, options);
+    if (!psbt) {
+      throw new Error("Could not parse PSBT. Invalid format.");
+    }
+    return psbt;
   } catch (e) {
     console.error("Error loading PSBT:", e);
     throw new Error(`Error loading PSBT: ${e.message}`);
@@ -118,7 +108,7 @@ export function loadPsbt(
 export function isPsbtV2(psbtText: string | Buffer): boolean {
   try {
     const version = getPsbtVersionNumber(psbtText);
-    return version >= 2;
+    return version === 2;
   } catch {
     return false;
   }

--- a/apps/coordinator/src/utils/psbtUtils.ts
+++ b/apps/coordinator/src/utils/psbtUtils.ts
@@ -11,7 +11,7 @@ import { Psbt } from "bitcoinjs-lib-v6"; // Used this instead from caravan/psbt 
  * Interface for UTXO data structure (This one is how utxo's are stored in Redux)
  *  TO-DO: Make all the various UTXO types we have in @caravan/client and @caravan/fees in sync
  */
-interface UTXO {
+export interface UTXO {
   confirmed: boolean;
   txid: string;
   index: number;
@@ -30,7 +30,7 @@ interface UTXO {
 /**
  * Interface for slice data structure
  */
-interface Slice {
+export interface Slice {
   multisig: any; // Type this more specifically based on our multisig structure
   bip32Path: string;
   change: boolean;
@@ -39,7 +39,7 @@ interface Slice {
 /**
  * Interface for input objects with multisig information
  */
-interface Input extends UTXO {
+export interface Input extends UTXO {
   multisig: Slice["multisig"]; // From slice.multisig
   bip32Path: Slice["bip32Path"]; // From slice.bip32Path
 }

--- a/apps/coordinator/src/utils/psbtUtils.ts
+++ b/apps/coordinator/src/utils/psbtUtils.ts
@@ -5,7 +5,7 @@ import {
   autoLoadPSBT as psbtPackageAutoLoad,
   validateMultisigPsbtSignature,
 } from "@caravan/psbt";
-import { Psbt } from "bitcoinjs-lib-v6";
+import { Psbt } from "bitcoinjs-lib-v6"; // Used this instead from caravan/psbt as `autoLoadPSBT` uses this Psbt Object
 
 /**
  * Interface for UTXO data structure (This one is how utxo's are stored in Redux)

--- a/apps/coordinator/src/utils/psbtUtils.ts
+++ b/apps/coordinator/src/utils/psbtUtils.ts
@@ -3,7 +3,6 @@ import {
   getPsbtVersionNumber,
   PsbtV2,
   autoLoadPSBT as psbtPackageAutoLoad,
-  validateMultisigPsbtSignature,
 } from "@caravan/psbt";
 import { Psbt } from "bitcoinjs-lib-v6"; // Used this instead from caravan/psbt as `autoLoadPSBT` uses this Psbt Object
 
@@ -47,7 +46,7 @@ export interface Input extends UTXO {
 /**
  * Interface for signature information extracted from PSBT
  */
-interface SignatureInfo {
+export interface SignatureInfo {
   signature: Buffer | string;
   pubkey: string;
   inputIndex: number;
@@ -56,7 +55,7 @@ interface SignatureInfo {
 /**
  * Interface for signature sets grouped by signer
  */
-interface SignatureSet {
+export interface SignatureSet {
   signatures: Buffer[] | string[];
   publicKeys: string[];
   signerPubkey: string;
@@ -107,189 +106,6 @@ export function loadPsbt(
     console.error("Error loading PSBT:", e);
     throw new Error(`Error loading PSBT: ${e.message}`);
   }
-}
-
-/**
- * Extracts signatures from a PSBT and organizes them by signer.
- *
- * @param  psbt - The PSBT object
- * @param  inputs - Array of input objects with multisig info
- * @param  outputs - Array of output objects
- * @param  network - Network (mainnet, testnet, etc.)
- * @returns  Array of signature sets, each containing signatures for all inputs
- */
-export function extractSignaturesFromPSBT(psbt: Psbt, inputs: Input[]) {
-  // Get all partial signatures from the PSBT
-  // Each input in a PSBT can have multiple partial signatures (one per signer)
-  const inputSignatures: SignatureInfo[][] = [];
-
-  for (let inputIndex = 0; inputIndex < psbt.data.inputs.length; inputIndex++) {
-    const input = psbt.data.inputs[inputIndex];
-    const inputSigs: SignatureInfo[] = [];
-
-    // So now , we Extract partial signatures from this input
-    // As partialSig is an array of {pubkey: Buffer, signature: Buffer
-    if (input.partialSig && input.partialSig.length > 0) {
-      for (const partialSig of input.partialSig) {
-        inputSigs.push({
-          signature: partialSig.signature.toString("hex"),
-          pubkey: partialSig.pubkey.toString("hex"),
-          inputIndex,
-        });
-      }
-    }
-
-    inputSignatures.push(inputSigs);
-  }
-
-  // Now we need to group signatures by signer
-  // In a multisig, each signer signs ALL inputs with the same key
-  // So we group signatures that use the same public key across all inputs
-  const signatureSets = groupSignaturesBySigner(psbt, inputSignatures, inputs);
-  return signatureSets;
-}
-
-/**
- * Groups signatures by signer (same pubkey across all inputs = same signer).
- *
- * @param  psbt - The PSBT object
- * @param  inputSignatures - Signatures organized by input
- * @param  inputs - Input objects for validation
- * @returns  Array of signature sets
- */
-function groupSignaturesBySigner(
-  psbt: Psbt,
-  inputSignatures: SignatureInfo[][],
-  inputs: Input[],
-): SignatureSet[] {
-  // Find all unique public keys across all inputs
-  const allPubkeys = new Set<string>();
-  inputSignatures.forEach((inputSigs) => {
-    inputSigs.forEach((sig) => allPubkeys.add(sig.pubkey));
-  });
-
-  const signatureSets: SignatureSet[] = [];
-
-  // For each unique pubkey, try to build a complete signature set
-  for (const pubkey of allPubkeys) {
-    const signatureSet: string[] = [];
-    const publicKeySet: string[] = [];
-    let isCompleteSet = true;
-
-    // Check if this pubkey has signed ALL inputs
-    for (let inputIndex = 0; inputIndex < inputs.length; inputIndex++) {
-      const inputSigs = inputSignatures[inputIndex];
-      const sigForThisPubkey = inputSigs.find((sig) => sig.pubkey === pubkey);
-
-      if (sigForThisPubkey) {
-        // Validate this signature to make sure it's correct
-        try {
-          const validatedPubkey = validateSignatureForInput(
-            sigForThisPubkey.signature as Buffer,
-            inputIndex,
-            psbt,
-            inputs,
-          );
-
-          if (validatedPubkey) {
-            signatureSet.push(sigForThisPubkey.signature as string);
-            publicKeySet.push(validatedPubkey);
-          } else {
-            console.warn(
-              `❌ Invalid signature for input ${inputIndex}, pubkey ${pubkey}`,
-            );
-            isCompleteSet = false;
-            break;
-          }
-        } catch (error) {
-          console.warn(
-            `❌ Error validating signature for input ${inputIndex}:`,
-            error.message,
-          );
-          isCompleteSet = false;
-          break;
-        }
-      } else {
-        // This pubkey didn't sign this input, so it's not a complete set
-        isCompleteSet = false;
-        break;
-      }
-    }
-
-    // Only add complete signature sets (where one signer signed ALL inputs)
-    if (isCompleteSet && signatureSet.length === inputs.length) {
-      signatureSets.push({
-        signatures: signatureSet,
-        publicKeys: publicKeySet,
-        signerPubkey: pubkey,
-      });
-    }
-  }
-
-  return signatureSets;
-}
-
-/**
- * Validates a signature for a specific input.
- *
- * @param signature - Hex-encoded signature
- * @param inputIndex - Index of the input being signed
- * @param originalPsbt - The original PSBT object we already have
- * @param inputs - All transaction inputs (for amountSats)
- * @returns The public key if valid, false if invalid
- */
-function validateSignatureForInput(
-  signature: Buffer,
-  inputIndex: number,
-  originalPsbt: Psbt,
-  inputs: Input[],
-): string | false {
-  try {
-    //  Handle empty signatures
-    if (!signature || signature.length === 0) {
-      return false;
-    }
-
-    const validatedPubkey = validateMultisigPsbtSignature(
-      originalPsbt.toBase64(),
-      inputIndex,
-      signature,
-      inputs[inputIndex].amountSats,
-    );
-
-    // Handle the case where validateMultisigPsbtSignature returns boolean true
-    // Convert true to false since we only want string (pubkey) or false
-    if (validatedPubkey === true) {
-      console.warn(
-        `Signature validation returned true but expected pubkey string for input ${inputIndex}`,
-      );
-      return false;
-    }
-    // Return the pubkey string or false
-    return validatedPubkey;
-  } catch (error) {
-    console.error(
-      `❌ Signature validation failed for input ${inputIndex + 1}:`,
-      error.message,
-    );
-    return false;
-  }
-}
-
-/**
- * Maps extracted signature sets to Caravan's signature importer format.
- *
- * @param signatureSets - Signature sets from extractSignaturesFromPSBT
- * @returns Array formatted for Caravan's signature importers
- */
-export function mapSignaturesToImporters(signatureSets: SignatureSet[]) {
-  return signatureSets.map((sigSet, index) => ({
-    importerNumber: index + 1, // As in Caravan we use 1-based indexing
-    signatures: sigSet.signatures,
-    publicKeys: sigSet.publicKeys,
-    signerPubkey: sigSet.signerPubkey,
-    finalized: true, // Mark as complete since we have all signatures
-  }));
 }
 
 /**

--- a/apps/coordinator/src/utils/psbtUtils.ts
+++ b/apps/coordinator/src/utils/psbtUtils.ts
@@ -48,7 +48,7 @@ interface Input extends UTXO {
  * Interface for signature information extracted from PSBT
  */
 interface SignatureInfo {
-  signature: Buffer;
+  signature: Buffer | string;
   pubkey: string;
   inputIndex: number;
 }
@@ -57,7 +57,7 @@ interface SignatureInfo {
  * Interface for signature sets grouped by signer
  */
 interface SignatureSet {
-  signatures: Buffer[];
+  signatures: Buffer[] | string[];
   publicKeys: string[];
   signerPubkey: string;
 }
@@ -132,7 +132,7 @@ export function extractSignaturesFromPSBT(psbt: Psbt, inputs: Input[]) {
     if (input.partialSig && input.partialSig.length > 0) {
       for (const partialSig of input.partialSig) {
         inputSigs.push({
-          signature: partialSig.signature,
+          signature: partialSig.signature.toString("hex"),
           pubkey: partialSig.pubkey.toString("hex"),
           inputIndex,
         });
@@ -172,7 +172,7 @@ function groupSignaturesBySigner(
 
   // For each unique pubkey, try to build a complete signature set
   for (const pubkey of allPubkeys) {
-    const signatureSet: Buffer[] = [];
+    const signatureSet: string[] = [];
     const publicKeySet: string[] = [];
     let isCompleteSet = true;
 
@@ -185,14 +185,14 @@ function groupSignaturesBySigner(
         // Validate this signature to make sure it's correct
         try {
           const validatedPubkey = validateSignatureForInput(
-            sigForThisPubkey.signature,
+            sigForThisPubkey.signature as Buffer,
             inputIndex,
             psbt,
             inputs,
           );
 
           if (validatedPubkey) {
-            signatureSet.push(sigForThisPubkey.signature);
+            signatureSet.push(sigForThisPubkey.signature as string);
             publicKeySet.push(validatedPubkey);
           } else {
             console.warn(

--- a/apps/coordinator/src/utils/psbtUtils.ts
+++ b/apps/coordinator/src/utils/psbtUtils.ts
@@ -50,6 +50,18 @@ export interface SignatureInfo {
   signature: Buffer | string;
   pubkey: string;
   inputIndex: number;
+  signerIndex?: number; // Which signer in the multisig (0, 1, 2, etc.)
+  derivedPubkey: string; // The actual derived pubkey for this input
+}
+
+export /**
+ * Interface for signer identification across multiple inputs
+ */
+interface SignerIdentity {
+  signerIndex: number; // Position in the multisig setup (0, 1, 2, etc.)
+  masterFingerprint?: string; // Master key fingerprint if available
+  signatures: Buffer[] | string[]; // Signatures for each input (in order)
+  publicKeys: string[]; // Derived pubkeys for each input (in order)
 }
 
 /**
@@ -58,7 +70,6 @@ export interface SignatureInfo {
 export interface SignatureSet {
   signatures: Buffer[] | string[];
   publicKeys: string[];
-  signerPubkey: string;
 }
 
 /**


### PR DESCRIPTION

###  **What kind of change does this PR introduce?**

Feature Added – Fixes the issue where importing a partially signed PSBT would not retain the existing partial signatures.

---

###  **Issue Number:**

Fixes #162 – *Import PSBT is not importing partial signatures*

---

### **Recreation Steps (Before the Fix):**

1. Create an unsigned PSBT in Caravan and download it.
2. Sign it outside Caravan using a compatible wallet/tool.
3. Re-import the wallet config and go to **Send > Import PSBT**.
4. Import the partially signed PSBT.
5. ❌ Observe: The partial signatures are not reflected, and Caravan treats it as unsigned.

---

###  **Summary of Changes:**

* **Core Fix**: Caravan previously failed to recognize and import partial signatures when reloading a PSBT. This PR introduces the necessary logic to parse and preserve those signatures correctly.
* **UI Enhancement**: Updated the Import PSBT flow to give visual feedback when signatures are present.
* **Refactor**: Cleaned up the import logic and modularized signature-handling utilities.
* **Type Fixes**: Added type safety for PSBT fields related to partial signatures.

---

###  **Snapshots/Videos:**
<img width="1110" alt="Screenshot 2025-06-07 at 20 09 59" src="https://github.com/user-attachments/assets/647ea684-9be6-4ac0-b93f-c7dbec11066c" />

---

### **Does this PR introduce a breaking change?**

No – this is a backward-compatible fix.

---

### **Checklist**

* [x] I have tested my changes thoroughly.
* [x] I have added or updated tests to cover my changes.
* [x] I have verified that test coverage meets or exceeds 95%.
* [x] I have run the test suite locally, and all tests pass.
* [x] I have followed the project's coding style and conventions.
* [x] I have created a changeset to document my changes (`npm run changeset`).

