### PR TITLE
 Dustchip | Dustchip file added on UI

### DIFF
--- a/.changeset/old-boats-train.md
+++ b/.changeset/old-boats-train.md
@@ -1,0 +1,5 @@
+---
+"caravan-coordinator": patch
+---
+
+Introduced the DustChip for coordinator.

--- a/apps/coordinator/package.json
+++ b/apps/coordinator/package.json
@@ -103,6 +103,7 @@
     "@caravan/psbt": "*",
     "@caravan/typescript-config": "*",
     "@caravan/wallets": "*",
+    "@caravan/health": "*",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@mui/icons-material": "^5.11.11",

--- a/apps/coordinator/src/components/ScriptExplorer/DustChip.tsx
+++ b/apps/coordinator/src/components/ScriptExplorer/DustChip.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { Tooltip, Chip } from "@mui/material";
+import { WasteMetrics } from "@caravan/health";
+import { getWalletConfig } from "../../selectors/wallet";
+
+interface DustChipProps {
+  amountSats: number;
+  feeRate: number;
+  tooltipText?: string;
+}
+/**
+ * DustChip component displays the dust status of a UTXO based on its amount and fee rate.
+ * It uses the WasteMetrics class to determine if the UTXO is economical, in warning range, or dust.
+ * It also provides a tooltip with additional information.
+ * @param {DustChipProps} props - Component properties
+ * @returns {JSX.Element} Rendered DustChip component
+ */
+
+const DustChip: React.FC<DustChipProps> = ({
+  amountSats,
+  feeRate,
+  tooltipText,
+}) => {
+  // Pull wallet settings from Redux
+  const walletConfig = useSelector(getWalletConfig);
+  const { addressType: scriptType, quorum } = walletConfig;
+
+  // Instantiate metrics and compute dust limits
+  const wasteMetrics = new WasteMetrics();
+  const config = {
+    requiredSignerCount: quorum.requiredSigners,
+    totalSignerCount: quorum.totalSigners,
+  };
+  const { lowerLimit, upperLimit } = wasteMetrics.calculateDustLimits(
+    feeRate,
+    scriptType,
+    config,
+  );
+
+  // Determine chip appearance
+  let color: "error" | "warning" | "success" = "success";
+  let label = "Economical";
+
+  if (amountSats <= lowerLimit) {
+    color = "error";
+    label = "Dust";
+  } else if (amountSats > lowerLimit && amountSats <= upperLimit) {
+    color = "warning";
+    label = "Warning";
+  }
+
+  // Fallback tooltip text based on range
+  const defaultTooltip = `This UTXO is ${
+    amountSats <= lowerLimit
+      ? "too small (dust) and costs more to spend than its value."
+      : amountSats <= upperLimit
+        ? "in the warning range; consider batching or consolidating."
+        : "economical to spend."
+  }`;
+
+  return (
+    <Tooltip title={tooltipText ?? defaultTooltip} arrow>
+      <Chip color={color} label={label} />
+    </Tooltip>
+  );
+};
+
+export default DustChip;

--- a/apps/coordinator/src/components/ScriptExplorer/UTXOSet.jsx
+++ b/apps/coordinator/src/components/ScriptExplorer/UTXOSet.jsx
@@ -19,6 +19,7 @@ import { OpenInNew } from "@mui/icons-material";
 import BigNumber from "bignumber.js";
 import { externalLink } from "utils/ExternalLink";
 import Copyable from "../Copyable";
+import DustChip from "./DustChip";
 
 // Actions
 import { setInputs as setInputsAction } from "../../actions/transactionActions";
@@ -171,7 +172,7 @@ class UTXOSet extends React.Component {
   };
 
   renderInputs = () => {
-    const { network, showSelection, finalizedOutputs } = this.props;
+    const { network, showSelection, finalizedOutputs, feeRate } = this.props;
     const { localInputs } = this.state;
     return localInputs.map((input, inputIndex) => {
       const confirmedStyle = `${styles.utxoTxid}${
@@ -202,6 +203,9 @@ class UTXOSet extends React.Component {
           </TableCell>
           <TableCell>
             <Copyable text={satoshisToBitcoins(input.amountSats)} />
+          </TableCell>
+          <TableCell>
+            <DustChip amountSats={input.amountSats} feeRate={feeRate} />
           </TableCell>
           <TableCell>
             {externalLink(
@@ -248,6 +252,7 @@ class UTXOSet extends React.Component {
               <TableCell>Index</TableCell>
               <TableCell>Amount (BTC)</TableCell>
               <TableCell>View</TableCell>
+              <TableCell>Dust Status</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>{this.renderInputs()}</TableBody>
@@ -284,6 +289,7 @@ UTXOSet.propTypes = {
   existingTransactionInputs: PropTypes.arrayOf(PropTypes.shape({})),
   setSpendCheckbox: PropTypes.func,
   autoSpend: PropTypes.bool.isRequired,
+  feeRate: PropTypes.string,
 };
 
 UTXOSet.defaultProps = {


### PR DESCRIPTION
This PR introduces a new DustChip component that classifies a UTXO amount as either:

Dust (too small to spend economically),

Warning (borderline wasteful), or

Economical

It uses WasteMetrics from @caravan/health to calculate dynamic dust thresholds based on:

The current feeRate

walletConfig (script type + quorum settings)

✅ Features
Supports custom tooltip via tooltipText prop

Falls back to default descriptions when no tooltip is provided

