### PR TITLE
fixes utxo extraction hooks to avoid infinite re-renders

### DIFF
--- a/apps/coordinator/src/clients/transactions.ts
+++ b/apps/coordinator/src/clients/transactions.ts
@@ -115,11 +115,12 @@ export interface Coin {
 }
 
 // Service function for fetching transaction coins (spendable outputs from prev txs)
-const fetchTransactionCoins = async (
-  transaction: TransactionDetails,
+export const fetchTransactionCoins = async (
+  txid: string,
   client: BlockchainClient,
 ) => {
   const coins = new Map<string, Coin>();
+  const transaction = await client.getTransaction(txid);
   for (const input of transaction.vin) {
     const { txid, vout } = input;
 
@@ -154,29 +155,4 @@ const fetchTransactionCoins = async (
     });
   }
   return coins;
-};
-
-/**
- * @description Fetches all the coins for a given transaction.
- * @param txid - The transaction ID to fetch coins from
- * @returns The coins from the transaction
- */
-export const useTransactionCoins = (txid: string) => {
-  const client = useGetClient();
-  const { data: transaction } = useFetchTransactionDetails(txid);
-
-  return useQuery({
-    queryKey: transactionKeys.coins(txid),
-    queryFn: async () => {
-      if (!transaction) {
-        throw new Error("Transaction not found");
-      }
-      const coins = await fetchTransactionCoins(transaction, client);
-      return {
-        transaction,
-        coins,
-      };
-    },
-    enabled: !!transaction && !!client,
-  });
 };

--- a/apps/coordinator/src/components/Wallet/TransactionsTab/FeeBumping/utils.ts
+++ b/apps/coordinator/src/components/Wallet/TransactionsTab/FeeBumping/utils.ts
@@ -67,6 +67,7 @@ export const validateTransactionInputs = (
   }
 };
 
+// TODO: remove this function when we do cleanup elsewhere around old rbf code
 /**
  * Efficiently combines and deduplicates UTXOs from multiple sources for fee bumping
  *


### PR DESCRIPTION
Non-user facing change but I found that the current setup for fetching tx input coins was causing infinite re-renders when working on #338. This extracts one of the calls out of a hook so that it can be more effectively memoized, thus avoiding the re-renders. I tested this change out in #338 already and confirmed it works. 