### PR TITLE
 Added parentUtxo parameter to `createCPFPTransaction`

### DIFF
--- a/.changeset/young-falcons-build.md
+++ b/.changeset/young-falcons-build.md
@@ -1,5 +1,0 @@
----
-"@caravan/fees": minor
----
-
-change CPFP function to require parentUTXO for cpfp operation

--- a/.changeset/young-falcons-build.md
+++ b/.changeset/young-falcons-build.md
@@ -1,0 +1,5 @@
+---
+"@caravan/fees": minor
+---
+
+change CPFP function to require parentUTXO for cpfp operation

--- a/packages/caravan-fees/src/tests/cpfp.fixtures.ts
+++ b/packages/caravan-fees/src/tests/cpfp.fixtures.ts
@@ -5,6 +5,36 @@ import { UTXO } from "../types";
 const parentTxHex =
   "020000000001019ef21963fbf5261d3b62f7f0467ab4b6d006b7d25a27d6744c95d9c11f577b210300000000ffffffff02713d0000000000001600147938bb5013f400246165f507ed015853430e28d2007c500200000000160014f2aecd6ab28d970ee8eea34665c181393b8754c60247304402201aaa53e645c14148171c3ea39841ee4ad7451d3a30f651e8a38ca20cec2cab9402206eab21ae37a5e0eaa0fe39d26821133e2c97297897de75b854865b5884a3523b012102b38786de2766d97e9d0341f9c2435b71242f0e41e887aebf8af5943afa7fa9b800000000";
 
+const parentTxid =
+  "77f437ae7f796896f1d69e2c9329202d6ac4b4a03fbc0f18e06dfab87f4b0702";
+const spendableOutputIndex = 1;
+
+// parent UTXO with full PSBT metadata
+const parentUtxo: UTXO = {
+  txid: parentTxid,
+  vout: spendableOutputIndex,
+  value: "38829056", // Value from output index 1 of parent transaction
+  prevTxHex: parentTxHex,
+  witnessUtxo: {
+    script: Buffer.from("0014f2aecd6ab28d970ee8eea34665c181393b8754c6", "hex"),
+    value: 38829056,
+  },
+  bip32Derivations: [
+    {
+      pubkey: Buffer.from(
+        "02b38786de2766d97e9d0341f9c2435b71242f0e41e887aebf8af5943afa7fa9b8",
+        "hex",
+      ),
+      masterFingerprint: Buffer.from("12345678", "hex"),
+      path: "m/48'/1'/0'/2'/0/0",
+    },
+  ],
+  witnessScript: Buffer.from(
+    "512102b38786de2766d97e9d0341f9c2435b71242f0e41e887aebf8af5943afa7fa9b851ae",
+    "hex",
+  ),
+};
+
 const availableUTXOs: UTXO[] = [
   {
     txid: "9805c05eebf91913601ed9024330b8a3d4fcc4d2503abf4dce5067cb011673c5",
@@ -42,6 +72,7 @@ export const cpfpValidFixtures = [
       originalTx: parentTxHex,
       availableInputs: availableUTXOs,
       spendableOutputIndex: 1,
+      parentUtxo: parentUtxo,
       changeAddress: "bc1q72hv664j3ktsa68w5drxtsvp8yacw4xxt7rvxm",
       network: Network.MAINNET,
       dustThreshold: "546",

--- a/packages/caravan-fees/src/tests/cpfp.fixtures.ts
+++ b/packages/caravan-fees/src/tests/cpfp.fixtures.ts
@@ -116,3 +116,83 @@ export const cpfpInvalidFixtures = [
   },
   // Removed the Dust output creation case, as now we use the parent tx to get the spendable output, as child tx's input so cannot override it's amount to create this invalid case .
 ];
+
+// Add these to your existing cpfpInvalidFixtures array
+export const cpfpParentUtxoValidationFixtures = [
+  {
+    case: "Parent UTXO txid mismatch",
+    options: {
+      ...cpfpValidFixtures[0].options,
+      parentUtxo: {
+        ...parentUtxo,
+        txid: "wrongtxid0000000000000000000000000000000000000000000000000000000000000000",
+      },
+    },
+    expectedError:
+      /Provided parent UTXO does not match the expected parent output/,
+  },
+  {
+    case: "Parent UTXO vout mismatch",
+    options: {
+      ...cpfpValidFixtures[0].options,
+      parentUtxo: {
+        ...parentUtxo,
+        vout: 0, // Wrong output index
+      },
+    },
+    expectedError:
+      /Provided parent UTXO does not match the expected parent output/,
+  },
+  {
+    case: "Parent UTXO value mismatch",
+    options: {
+      ...cpfpValidFixtures[0].options,
+      parentUtxo: {
+        ...parentUtxo,
+        value: "1000000", // Wrong value
+      },
+    },
+    expectedError:
+      /Provided parent UTXO does not match the expected parent output/,
+  },
+];
+
+export const cpfpMissingPsbtFieldsFixtures = [
+  {
+    case: "Missing witnessUtxo and nonWitnessUtxo",
+    options: {
+      ...cpfpValidFixtures[0].options,
+      parentUtxo: {
+        ...parentUtxo,
+        witnessUtxo: undefined,
+        nonWitnessUtxo: undefined,
+      },
+    },
+    expectedError:
+      /Parent UTXO is missing required witnessUtxo or nonWitnessUtxo field/,
+  },
+  {
+    case: "Missing bip32Derivations",
+    options: {
+      ...cpfpValidFixtures[0].options,
+      parentUtxo: {
+        ...parentUtxo,
+        bip32Derivations: undefined,
+      },
+    },
+    expectedError:
+      /Parent UTXO is missing required bip32Derivations for multisig signing/,
+  },
+  {
+    case: "Empty bip32Derivations array",
+    options: {
+      ...cpfpValidFixtures[0].options,
+      parentUtxo: {
+        ...parentUtxo,
+        bip32Derivations: [],
+      },
+    },
+    expectedError:
+      /Parent UTXO is missing required bip32Derivations for multisig signing/,
+  },
+];

--- a/packages/caravan-fees/src/tests/cpfp.fixtures.ts
+++ b/packages/caravan-fees/src/tests/cpfp.fixtures.ts
@@ -95,6 +95,18 @@ export const cpfpValidFixtures = [
         address: "bc1q72hv664j3ktsa68w5drxtsvp8yacw4xxt7rvxm",
         value: "38828300",
       },
+      psbtFields: {
+        witnessUtxo:
+          "007c500200000000160014f2aecd6ab28d970ee8eea34665c181393b8754c6",
+        // BIP32 derivation key: 06 (key type) + pubkey
+        bip32DerivationKey:
+          "0602b38786de2766d97e9d0341f9c2435b71242f0e41e887aebf8af5943afa7fa9b8",
+        // BIP32 derivation value: master fingerprint + encoded path
+        bip32DerivationValue:
+          "12345678300000800100008000000080020000800000000000000000",
+        witnessScript:
+          "512102b38786de2766d97e9d0341f9c2435b71242f0e41e887aebf8af5943afa7fa9b851ae",
+      },
     },
   },
 ];

--- a/packages/caravan-fees/src/tests/cpfp.fixtures.ts
+++ b/packages/caravan-fees/src/tests/cpfp.fixtures.ts
@@ -117,7 +117,6 @@ export const cpfpInvalidFixtures = [
   // Removed the Dust output creation case, as now we use the parent tx to get the spendable output, as child tx's input so cannot override it's amount to create this invalid case .
 ];
 
-// Add these to your existing cpfpInvalidFixtures array
 export const cpfpParentUtxoValidationFixtures = [
   {
     case: "Parent UTXO txid mismatch",

--- a/packages/caravan-fees/src/tests/cpfp.test.ts
+++ b/packages/caravan-fees/src/tests/cpfp.test.ts
@@ -10,7 +10,12 @@ import {
   reverseHex,
 } from "../utils";
 
-import { cpfpValidFixtures, cpfpInvalidFixtures } from "./cpfp.fixtures";
+import {
+  cpfpValidFixtures,
+  cpfpInvalidFixtures,
+  cpfpMissingPsbtFieldsFixtures,
+  cpfpParentUtxoValidationFixtures,
+} from "./cpfp.fixtures";
 
 describe("CPFP Transaction Creation", () => {
   describe("Valid CPFP Transactions", () => {
@@ -47,6 +52,11 @@ describe("CPFP Transaction Creation", () => {
         expect(psbt.PSBT_IN_OUTPUT_INDEX[0]).toBe(
           fixture.options.spendableOutputIndex,
         );
+
+        // Verify parent UTXO PSBT fields are present
+        expect(psbt.PSBT_IN_WITNESS_UTXO[0]).toBeDefined();
+        expect(psbt.PSBT_IN_BIP32_DERIVATION[0]).toBeDefined();
+        expect(psbt.PSBT_IN_WITNESS_SCRIPT[0]).toBeDefined();
 
         // Step 5: Verify change output
         expect(psbt.PSBT_OUT_SCRIPT[0]).toContain(
@@ -92,6 +102,27 @@ describe("CPFP Transaction Creation", () => {
     cpfpInvalidFixtures.forEach((fixture) => {
       it(fixture.case, () => {
         expect(() => createCPFPTransaction(fixture.options)).toThrow();
+      });
+    });
+  });
+
+  describe("Parent UTXO Validation", () => {
+    cpfpParentUtxoValidationFixtures.forEach((fixture) => {
+      it(fixture.case, () => {
+        expect(() => createCPFPTransaction(fixture.options)).toThrow(
+          fixture.expectedError,
+        );
+      });
+    });
+  });
+
+  // NEW: Missing PSBT fields tests
+  describe("Missing PSBT Fields", () => {
+    cpfpMissingPsbtFieldsFixtures.forEach((fixture) => {
+      it(fixture.case, () => {
+        expect(() => createCPFPTransaction(fixture.options)).toThrow(
+          fixture.expectedError,
+        );
       });
     });
   });

--- a/packages/caravan-fees/src/tests/cpfp.test.ts
+++ b/packages/caravan-fees/src/tests/cpfp.test.ts
@@ -54,9 +54,20 @@ describe("CPFP Transaction Creation", () => {
         );
 
         // Verify parent UTXO PSBT fields are present
-        expect(psbt.PSBT_IN_WITNESS_UTXO[0]).toBeDefined();
-        expect(psbt.PSBT_IN_BIP32_DERIVATION[0]).toBeDefined();
-        expect(psbt.PSBT_IN_WITNESS_SCRIPT[0]).toBeDefined();
+        expect(psbt.PSBT_IN_WITNESS_UTXO[0]).toEqual(
+          fixture.expected.psbtFields.witnessUtxo,
+        );
+
+        const bip32Derivation = psbt.PSBT_IN_BIP32_DERIVATION[0][0]; // BIP32 derivation returns key-value pairs
+        expect(bip32Derivation.key).toBe(
+          fixture.expected.psbtFields.bip32DerivationKey,
+        );
+        expect(bip32Derivation.value).toBe(
+          fixture.expected.psbtFields.bip32DerivationValue,
+        );
+        expect(psbt.PSBT_IN_WITNESS_SCRIPT[0]).toBe(
+          fixture.expected.psbtFields.witnessScript,
+        );
 
         // Step 5: Verify change output
         expect(psbt.PSBT_OUT_SCRIPT[0]).toContain(
@@ -116,7 +127,6 @@ describe("CPFP Transaction Creation", () => {
     });
   });
 
-  // NEW: Missing PSBT fields tests
   describe("Missing PSBT Fields", () => {
     cpfpMissingPsbtFieldsFixtures.forEach((fixture) => {
       it(fixture.case, () => {

--- a/packages/caravan-fees/src/tests/psbtTestCpfp.fixtures.ts
+++ b/packages/caravan-fees/src/tests/psbtTestCpfp.fixtures.ts
@@ -23,11 +23,15 @@ import { Network, P2WSH } from "@caravan/bitcoin";
  * - The transaction has a change output back to your wallet
  * - You spend your own change output to create a CPFP transaction
  *
- * ## What We're Testing:
- * - That the parent output is correctly identified and enriched with PSBT metadata
- * - That the child transaction properly references the parent transaction
- * - That all necessary signing information (scripts, derivations) is present
- * - That the combined fee rate achieves the target acceleration
+ *
+ * Each test follows this pattern:
+ * 1. Start with a real unconfirmed transaction (parent)
+ * 2. Identify a spendable output from that transaction
+ * 3. Create a CPFP transaction that spends that output
+ * 4. Verify the generated PSBT matches our expected binary output exactly
+ *
+ * The "exactPsbt" field in fixtures contains the precise PSBT we expect our
+ * code to generate. This ensures no regressions in PSBT generation logic.
  *
  * What we're NOT testing here:
  * - Fee calculation logic (that's covered in separate tests)
@@ -58,7 +62,7 @@ export const cpfpPsbtFixtures = {
       // The parent UTXO - this is output 1 from the parent transaction
       // This output was sent TO US, so we have the signing keys and can spend it
       parentUtxo: {
-        txid: "db9bccbcc5d74bf23faac7de67b45d81a8ca1370f7b312f4c2d2b291f1666570",
+        txid: "706566f191b2d2c2f412b3f77013caa8815db467dec7aa3ff24bd7c5bccc9bdb",
         vout: 1, // Spending output index 1 (the one sent to our wallet)
         value: "100000000", // 1 BTC in satoshis
         prevTxHex:
@@ -139,10 +143,10 @@ export const cpfpPsbtFixtures = {
         parentVsize: 140.25,
         childInputCount: 1, // Only spending the parent output
         childOutputCount: 1, // Only one change output
-        combinedFeeRate: 32.5, // Achieved combined fee rate
+        combinedFeeRate: 39.7, // Achieved combined fee rate
         // The exact PSBT we expect to generate for this CPFP transaction
         exactPsbt:
-          "cHNidP8B+wQCAAAAAQIEAgAAAAEEAQEBBQEBAQMEAAAAAAEGAQNPAQQ1h88Dgl2SPYAAAAA1gVrVrrCaAW77pvICudYT1OgMKWDHqygcNSGGEkGHtgOdMV/Gaa1omz+62G2Nk86Bp394s033WzYxU10IL4gndhBzmxmnVAAAgAEAAIAAAACATwEENYfPA13Er/mAAAAAXIkZAJ6zR6nZcfefzibOf8yIfgZw/MEBt3mO/wcS3tUC0m1lmogMBUHKndl7pk8FE6bqDneo61acMUMLVwZ3YpYQxzpCNlQAAIABAACAAAAAgE8BBDWHzwPmwZ+cgAAAAKgJSKesi1xqjMGyDjwGyadlp3IKHoSuCeqQobWE26BsAnYI4VTYWIrnlYwnBhG0SKKBnaJTTXHYnfQVPuD75Ba0EM4hZYJUAACAAQAAgAAAAIAAAQ4g25vMvMXXS/I/qsfeZ7RdgajKE3D3sxL0wtKykfFmZXABDwQBAAAAAQDNAgAAAAABAcuZhRB270eyF5uZ9NZkes2JmYC7QzBcSM/GgxYTuikUAAAAAAD9////AgJndM4CAAAAIlEgwgRxu/eg0TNg0SfBd8xyO3SgOq0IBq+cYsfn6aSUGmkA4fUFAAAAACIAICn+8vRBEU+5VfeZTXt8FONmSZDcEXUc88e/6D+SROL/AUBCV2GrTX0G0hgsnYix+yuKPSXrgWcqQJRDLsbzviRinoL43qPokzfBpfyc66J+0GbyQWU+Bt88htzwg3AqQTF3AAAAAAEBcgDh9QUAAAAAaVIhAjY9pkhm1G9ybFB0geUquQMKOzT+pnil4pC3tJC0X2OAIQKW1q44thLR57znb7mb9hJZPubSuAQsrNk5/7aeXmniaSEDC+2bcYNaXdfUW8cvtIpX8qM5bgyuVJ+4P+fwO4J80JRTrgEFaVIhAjY9pkhm1G9ybFB0geUquQMKOzT+pnil4pC3tJC0X2OAIQKW1q44thLR57znb7mb9hJZPubSuAQsrNk5/7aeXmniaSEDC+2bcYNaXdfUW8cvtIpX8qM5bgyuVJ+4P+fwO4J80JRTriIGAjY9pkhm1G9ybFB0geUquQMKOzT+pnil4pC3tJC0X2OAGHObGadUAACAAQAAgAAAAIAAAAAAEQAAACIGApbWrji2EtHnvOdvuZv2Elk+5tK4BCys2Tn/tp5eaeJpGMc6QjZUAACAAQAAgAAAAIAAAAAAEQAAACIGAwvtm3GDWl3X1FvHL7SKV/KjOW4MrlSfuD/n8DuCfNCUGM4hZYJUAACAAQAAgAAAAIAAAAAAEQAAAAABAwgDv/UFAAAAAAEEIgAgkaeXjJOPqXV0taM43yaCh16Fv+TvQ22/sHBWVpJH+DAA",
+          "cHNidP8B+wQCAAAAAQIEAgAAAAEEAQEBBQEBAQMEAAAAAAEGAQNPAQQ1h88Dgl2SPYAAAAA1gVrVrrCaAW77pvICudYT1OgMKWDHqygcNSGGEkGHtgOdMV/Gaa1omz+62G2Nk86Bp394s033WzYxU10IL4gndhBzmxmnVAAAgAEAAIAAAACATwEENYfPA13Er/mAAAAAXIkZAJ6zR6nZcfefzibOf8yIfgZw/MEBt3mO/wcS3tUC0m1lmogMBUHKndl7pk8FE6bqDneo61acMUMLVwZ3YpYQxzpCNlQAAIABAACAAAAAgE8BBDWHzwPmwZ+cgAAAAKgJSKesi1xqjMGyDjwGyadlp3IKHoSuCeqQobWE26BsAnYI4VTYWIrnlYwnBhG0SKKBnaJTTXHYnfQVPuD75Ba0EM4hZYJUAACAAQAAgAAAAIAAAQ4g25vMvMXXS/I/qsfeZ7RdgajKE3D3sxL0wtKykfFmZXABDwQBAAAAAQDNAgAAAAABAcuZhRB270eyF5uZ9NZkes2JmYC7QzBcSM/GgxYTuikUAAAAAAD9////AgJndM4CAAAAIlEgwgRxu/eg0TNg0SfBd8xyO3SgOq0IBq+cYsfn6aSUGmkA4fUFAAAAACIAICn+8vRBEU+5VfeZTXt8FONmSZDcEXUc88e/6D+SROL/AUBCV2GrTX0G0hgsnYix+yuKPSXrgWcqQJRDLsbzviRinoL43qPokzfBpfyc66J+0GbyQWU+Bt88htzwg3AqQTF3AAAAAAEBewDh9QUAAAAAcgDh9QUAAAAAaVIhAjY9pkhm1G9ybFB0geUquQMKOzT+pnil4pC3tJC0X2OAIQKW1q44thLR57znb7mb9hJZPubSuAQsrNk5/7aeXmniaSEDC+2bcYNaXdfUW8cvtIpX8qM5bgyuVJ+4P+fwO4J80JRTrgEFaVIhAjY9pkhm1G9ybFB0geUquQMKOzT+pnil4pC3tJC0X2OAIQKW1q44thLR57znb7mb9hJZPubSuAQsrNk5/7aeXmniaSEDC+2bcYNaXdfUW8cvtIpX8qM5bgyuVJ+4P+fwO4J80JRTriIGAjY9pkhm1G9ybFB0geUquQMKOzT+pnil4pC3tJC0X2OAGHObGadUAACAAQAAgAAAAIAAAAAAEQAAACIGApbWrji2EtHnvOdvuZv2Elk+5tK4BCys2Tn/tp5eaeJpGMc6QjZUAACAAQAAgAAAAIAAAAAAEQAAACIGAwvtm3GDWl3X1FvHL7SKV/KjOW4MrlSfuD/n8DuCfNCUGM4hZYJUAACAAQAAgAAAAIAAAAAAEQAAAAABAwhRv/UFAAAAAAEEIgAgkaeXjJOPqXV0taM43yaCh16Fv+TvQ22/sHBWVpJH+DAA",
       },
     },
   ],
@@ -238,7 +242,7 @@ export const cpfpPsbtFixtures = {
 
       expected: {
         parentTxid:
-          "8bc8d3a82ec6ce9725b42699aa0040143122857a919a4a39e5063052be6542c0",
+          "c04265be523006e5394a9a917a852231144000aa9926b42597cec62ea8d3c88b",
         parentFee: 2020,
         parentVsize: 188.5,
         childInputCount: 1, // Only spending the parent change output
@@ -246,7 +250,7 @@ export const cpfpPsbtFixtures = {
         combinedFeeRate: 32.5, // Achieved combined fee rate
         // The exact PSBT we expect to generate for this CPFP transaction
         exactPsbt:
-          "cHNidP8B+wQCAAAAAQIEAgAAAAEEAQEBBQEBAQMEAAAAAAEGAQNPAQQ1h88Dgl2SPYAAAAA1gVrVrrCaAW77pvICudYT1OgMKWDHqygcNSGGEkGHtgOdMV/Gaa1omz+62G2Nk86Bp394s033WzYxU10IL4gndhBzmxmnVAAAgAEAAIAAAACATwEENYfPA13Er/mAAAAAXIkZAJ6zR6nZcfefzibOf8yIfgZw/MEBt3mO/wcS3tUC0m1lmogMBUHKndl7pk8FE6bqDneo61acMUMLVwZ3YpYQxzpCNlQAAIABAACAAAAAgE8BBDWHzwPmwZ+cgAAAAKgJSKesi1xqjMGyDjwGyadlp3IKHoSuCeqQobWE26BsAnYI4VTYWIrnlYwnBhG0SKKBnaJTTXHYnfQVPuD75Ba0EM4hZYJUAACAAQAAgAAAAIAAAQ4gi8jTqC7GzpcltCaZqgBAFDEihXqRmko55QYwUr5lQsABDwQBAAAAAQD9ewEBAAAAAAEBy5mFEHbvR7IXm5n01mR6zYmZgLtDMFxIz8aDFhO6KRQBAAAAAP3///8CAOH1BQAAAAAWABRlAYJUmyFd5gB9KGlmZ1xpvCV/iBx81xcAAAAAIgAgx/idn3OZXZ64ZJuoRdX0lYb4L7d6dFnb8I+Ioib+k4UEAEcwRAIgUgJMf2qvUcpKPTykuiNde6NT4oDo6s4zaNuE08qKI9sCIH56qjZ5KkUjfHq18cJh1fjvkzXhLcTjl/HTFFAX3lxNAUcwRAIgfbnydi4CJQOz868rxOEUiiTGFnNB3zR4JPiSrRhw00ICIBOm3P0O8EwEcvR6k+IJ4xnSMrOU6UZ/obyXnqHzCWObAWlSIQInwGBL8yzeLsKVgBw/aZqsLYFCip7yHgtILh5AYc+XZiECpI0DKo11tCzXkWUEwERPxY9Mm8kbBPPU/pF2PTJKvhkhAvbgWt6c2SJml/mXsVwLwz/EUntyYHUQObs7x2r8XwIvU64AAAAAAQFyHHzXFwAAAABpUiECgyskacpmzLcsAe9kQRYMFEDSvbLzV8EknajhPIL9gzIhAtMtP7JqZNWBezS9DkbvVSUs4oiNozQo+JULB8kPQ+toIQNgRGjneDr9aVL+37uV3lAx/bCEx2c8bJumnfvsk2zk61OuAQVpUiECgyskacpmzLcsAe9kQRYMFEDSvbLzV8EknajhPIL9gzIhAtMtP7JqZNWBezS9DkbvVSUs4oiNozQo+JULB8kPQ+toIQNgRGjneDr9aVL+37uV3lAx/bCEx2c8bJumnfvsk2zk61OuIgYC0y0/smpk1YF7NL0ORu9VJSziiI2jNCj4lQsHyQ9D62gYc5sZp1QAAIABAACAAAAAgAEAAAARAAAAIgYCgyskacpmzLcsAe9kQRYMFEDSvbLzV8EknajhPIL9gzIYxzpCNlQAAIABAACAAAAAgAEAAAARAAAAIgYDYERo53g6/WlS/t+7ld5QMf2whMdnPGybpp377JNs5OsYziFlglQAAIABAACAAAAAgAEAAAARAAAAAAEDCHpX1xcAAAAAAQQiACCRp5eMk4+pdXS1ozjfJoKHXoW/5O9Dbb+wcFZWkkf4MAA=",
+          "cHNidP8B+wQCAAAAAQIEAgAAAAEEAQEBBQEBAQMEAAAAAAEGAQNPAQQ1h88Dgl2SPYAAAAA1gVrVrrCaAW77pvICudYT1OgMKWDHqygcNSGGEkGHtgOdMV/Gaa1omz+62G2Nk86Bp394s033WzYxU10IL4gndhBzmxmnVAAAgAEAAIAAAACATwEENYfPA13Er/mAAAAAXIkZAJ6zR6nZcfefzibOf8yIfgZw/MEBt3mO/wcS3tUC0m1lmogMBUHKndl7pk8FE6bqDneo61acMUMLVwZ3YpYQxzpCNlQAAIABAACAAAAAgE8BBDWHzwPmwZ+cgAAAAKgJSKesi1xqjMGyDjwGyadlp3IKHoSuCeqQobWE26BsAnYI4VTYWIrnlYwnBhG0SKKBnaJTTXHYnfQVPuD75Ba0EM4hZYJUAACAAQAAgAAAAIAAAQ4gi8jTqC7GzpcltCaZqgBAFDEihXqRmko55QYwUr5lQsABDwQBAAAAAQD9ewEBAAAAAAEBy5mFEHbvR7IXm5n01mR6zYmZgLtDMFxIz8aDFhO6KRQBAAAAAP3///8CAOH1BQAAAAAWABRlAYJUmyFd5gB9KGlmZ1xpvCV/iBx81xcAAAAAIgAgx/idn3OZXZ64ZJuoRdX0lYb4L7d6dFnb8I+Ioib+k4UEAEcwRAIgUgJMf2qvUcpKPTykuiNde6NT4oDo6s4zaNuE08qKI9sCIH56qjZ5KkUjfHq18cJh1fjvkzXhLcTjl/HTFFAX3lxNAUcwRAIgfbnydi4CJQOz868rxOEUiiTGFnNB3zR4JPiSrRhw00ICIBOm3P0O8EwEcvR6k+IJ4xnSMrOU6UZ/obyXnqHzCWObAWlSIQInwGBL8yzeLsKVgBw/aZqsLYFCip7yHgtILh5AYc+XZiECpI0DKo11tCzXkWUEwERPxY9Mm8kbBPPU/pF2PTJKvhkhAvbgWt6c2SJml/mXsVwLwz/EUntyYHUQObs7x2r8XwIvU64AAAAAAQF7HHzXFwAAAAByHHzXFwAAAABpUiECgyskacpmzLcsAe9kQRYMFEDSvbLzV8EknajhPIL9gzIhAtMtP7JqZNWBezS9DkbvVSUs4oiNozQo+JULB8kPQ+toIQNgRGjneDr9aVL+37uV3lAx/bCEx2c8bJumnfvsk2zk61OuAQVpUiECgyskacpmzLcsAe9kQRYMFEDSvbLzV8EknajhPIL9gzIhAtMtP7JqZNWBezS9DkbvVSUs4oiNozQo+JULB8kPQ+toIQNgRGjneDr9aVL+37uV3lAx/bCEx2c8bJumnfvsk2zk61OuIgYCgyskacpmzLcsAe9kQRYMFEDSvbLzV8EknajhPIL9gzIYxzpCNlQAAIABAACAAAAAgAEAAAARAAAAIgYC0y0/smpk1YF7NL0ORu9VJSziiI2jNCj4lQsHyQ9D62gYc5sZp1QAAIABAACAAAAAgAEAAAARAAAAIgYDYERo53g6/WlS/t+7ld5QMf2whMdnPGybpp377JNs5OsYziFlglQAAIABAACAAAAAgAEAAAARAAAAAAEDCNJX1xcAAAAAAQQiACCRp5eMk4+pdXS1ozjfJoKHXoW/5O9Dbb+wcFZWkkf4MAA=",
       },
     },
   ],

--- a/packages/caravan-fees/src/tests/psbtTestCpfp.fixtures.ts
+++ b/packages/caravan-fees/src/tests/psbtTestCpfp.fixtures.ts
@@ -1,0 +1,253 @@
+import { Network, P2WSH } from "@caravan/bitcoin";
+
+/**
+ * CPFP (Child-Pays-for-Parent) Test Fixtures
+ *
+ * These fixtures test our CPFP functionality by simulating real-world scenarios where users
+ * need to speed up stuck transactions by spending outputs from unconfirmed parent transactions.
+ *
+ * ## How CPFP Works:
+ * 1. You have an unconfirmed transaction (the "parent") stuck in the mempool
+ * 2. You create a new transaction (the "child") that spends an output from the parent
+ * 3. The child pays a high enough fee to incentivize miners to confirm both transactions
+ *
+ * ## Test Scenarios:
+ *
+ * ### Scenario 1: Receiving Transaction CPFP
+ * - Someone sent you Bitcoin, but used a low fee
+ * - The transaction is stuck, and you want to speed it up
+ * - You spend the output they sent to you in a CPFP transaction
+ *
+ * ### Scenario 2: Sent Transaction CPFP
+ * - You sent Bitcoin but used too low a fee
+ * - The transaction has a change output back to your wallet
+ * - You spend your own change output to create a CPFP transaction
+ *
+ * ## What We're Testing:
+ * - That the parent output is correctly identified and enriched with PSBT metadata
+ * - That the child transaction properly references the parent transaction
+ * - That all necessary signing information (scripts, derivations) is present
+ * - That the combined fee rate achieves the target acceleration
+ *
+ * What we're NOT testing here:
+ * - Fee calculation logic (that's covered in separate tests)
+ *
+ * Pro tip: You can paste any of these PSBTs into BIP370.org to inspect them visually
+ * and verify they're valid. All PSBTs in this fixture use version 2 format.
+ *
+ * The test methodology is straightforward - we just want to ensure that given proper
+ * input data, our fee-bumping function outputs a well-formed PSBT that maintains all
+ * the necessary transaction components while properly adjusting for the new fee rate.
+ */
+
+export const cpfpPsbtFixtures = {
+  receivingTransaction: [
+    {
+      case: "CPFP on incoming payment - Spending received output to accelerate confirmation",
+      // This simulates someone sending our wallet Bitcoin with a low fee, and then we use CPFP to speed it up
+      // Parent tx: 706566f191b2d2c2f412b3f77013caa8815db467dec7aa3ff24bd7c5bccc9bdb (receiving 1 BTC)
+      // We're spending output 1 (the one sent to us) to create a child transaction
+
+      parentTransaction: {
+        txid: "706566f191b2d2c2f412b3f77013caa8815db467dec7aa3ff24bd7c5bccc9bdb",
+        hex: "02000000000101cb99851076ef47b2179b99f4d6647acd899980bb43305c48cfc6831613ba29140000000000fdffffff02026774ce02000000225120c20471bbf7a0d13360d127c177cc723b74a03aad0806af9c62c7e7e9a4941a6900e1f5050000000022002029fef2f441114fb955f7994d7b7c14e3664990dc11751cf3c7bfe83f9244e2ff0140425761ab4d7d06d2182c9d88b1fb2b8a3d25eb81672a4094432ec6f3be24629e82f8dea3e89337c1a5fc9ceba27ed066f241653e06df3c86dcf083702a41317700000000",
+        fee: 1550, // Parent transaction fee (low fee causing the delay)
+        vsize: 140.25,
+      },
+
+      // The parent UTXO - this is output 1 from the parent transaction
+      // This output was sent TO US, so we have the signing keys and can spend it
+      parentUtxo: {
+        txid: "db9bccbcc5d74bf23faac7de67b45d81a8ca1370f7b312f4c2d2b291f1666570",
+        vout: 1, // Spending output index 1 (the one sent to our wallet)
+        value: "100000000", // 1 BTC in satoshis
+        prevTxHex:
+          "02000000000101cb99851076ef47b2179b99f4d6647acd899980bb43305c48cfc6831613ba29140000000000fdffffff02026774ce02000000225120c20471bbf7a0d13360d127c177cc723b74a03aad0806af9c62c7e7e9a4941a6900e1f5050000000022002029fef2f441114fb955f7994d7b7c14e3664990dc11751cf3c7bfe83f9244e2ff0140425761ab4d7d06d2182c9d88b1fb2b8a3d25eb81672a4094432ec6f3be24629e82f8dea3e89337c1a5fc9ceba27ed066f241653e06df3c86dcf083702a41317700000000",
+        witnessUtxo: {
+          script: Buffer.from(
+            "00e1f5050000000069522102363da64866d46f726c507481e52ab9030a3b34fea678a5e290b7b490b45f6380210296d6ae38b612d1e7bce76fb99bf612593ee6d2b8042cacd939ffb69e5e69e26921030bed9b71835a5dd7d45bc72fb48a57f2a3396e0cae549fb83fe7f03b827cd09453ae",
+            "hex",
+          ),
+          value: 100000000,
+        },
+        witnessScript: Buffer.from(
+          "522102363da64866d46f726c507481e52ab9030a3b34fea678a5e290b7b490b45f6380210296d6ae38b612d1e7bce76fb99bf612593ee6d2b8042cacd939ffb69e5e69e26921030bed9b71835a5dd7d45bc72fb48a57f2a3396e0cae549fb83fe7f03b827cd09453ae",
+          "hex",
+        ),
+        bip32Derivations: [
+          {
+            pubkey: Buffer.from(
+              "02363da64866d46f726c507481e52ab9030a3b34fea678a5e290b7b490b45f6380",
+              "hex",
+            ),
+            masterFingerprint: Buffer.from("739b19a7", "hex"),
+            path: "m/84'/1'/0'/0/17", // This is a receiving address (path 0)
+          },
+          {
+            pubkey: Buffer.from(
+              "0296d6ae38b612d1e7bce76fb99bf612593ee6d2b8042cacd939ffb69e5e69e269",
+              "hex",
+            ),
+            masterFingerprint: Buffer.from("c73a4236", "hex"),
+            path: "m/84'/1'/0'/0/17",
+          },
+          {
+            pubkey: Buffer.from(
+              "030bed9b71835a5dd7d45bc72fb48a57f2a3396e0cae549fb83fe7f03b827cd094",
+              "hex",
+            ),
+            masterFingerprint: Buffer.from("ce216582", "hex"),
+            path: "m/84'/1'/0'/0/17",
+          },
+        ],
+      },
+
+      // Additional UTXOs available for adding more inputs if needed for higher fees
+      availableUtxos: [], // In this case, the parent output alone is sufficient
+
+      spendableOutputIndex: 1, // We're spending output 1 from the parent
+      changeAddress:
+        "bcrt1qjxne0ryn375h2a945vud7f5zsa0gt0lyaapkm0aswpt9dyj8lqcq94eqw4", // address we want to send the funds to in child Tx
+      network: Network.REGTEST,
+      dustThreshold: "546",
+      scriptType: P2WSH,
+      requiredSigners: 2,
+      totalSigners: 3,
+      targetFeeRate: 32.5, // Target combined fee rate (parent + child)
+      globalXpubs: [
+        {
+          xpub: "tpubDCyyVFP5xvLjEtEnUd3ycp8U7m5TZwt8B9q32bBytWEVRaTSWwiWjcR27yJLtgRvJdqbrEupi3vCaDfwZPbL8ViytwYnyeTYeZeDfvyJAMc",
+          masterFingerprint: "739b19a7",
+          path: "m/84'/1'/0'",
+        },
+        {
+          xpub: "tpubDCiNatUPEtNj633QZvvfweoL4VziJe33CVGi4ZKEquVsNmRnwkfqxp4QZMp1GcjcVScyXru3qGna19QH9tTEsqVV7Jf8vgAKTDPFfoYQZZf",
+          masterFingerprint: "c73a4236",
+          path: "m/84'/1'/0'",
+        },
+        {
+          xpub: "tpubDDimkbNa9cUM3y6vTJ39TGGbAENXMHrH81SmY7aQZtVLcAFQSLYtzzj5PpMrfcNx2bnGjtqgPRdqRx6aWudEuqpbBWpJYPdfJQYkKec6JgY",
+          masterFingerprint: "ce216582",
+          path: "m/84'/1'/0'",
+        },
+      ],
+
+      expected: {
+        parentTxid:
+          "706566f191b2d2c2f412b3f77013caa8815db467dec7aa3ff24bd7c5bccc9bdb",
+        parentFee: 1550,
+        parentVsize: 140.25,
+        childInputCount: 1, // Only spending the parent output
+        childOutputCount: 1, // Only one change output
+        combinedFeeRate: 32.5, // Achieved combined fee rate
+        // The exact PSBT we expect to generate for this CPFP transaction
+        exactPsbt:
+          "cHNidP8B+wQCAAAAAQIEAgAAAAEEAQEBBQEBAQMEAAAAAAEGAQNPAQQ1h88Dgl2SPYAAAAA1gVrVrrCaAW77pvICudYT1OgMKWDHqygcNSGGEkGHtgOdMV/Gaa1omz+62G2Nk86Bp394s033WzYxU10IL4gndhBzmxmnVAAAgAEAAIAAAACATwEENYfPA13Er/mAAAAAXIkZAJ6zR6nZcfefzibOf8yIfgZw/MEBt3mO/wcS3tUC0m1lmogMBUHKndl7pk8FE6bqDneo61acMUMLVwZ3YpYQxzpCNlQAAIABAACAAAAAgE8BBDWHzwPmwZ+cgAAAAKgJSKesi1xqjMGyDjwGyadlp3IKHoSuCeqQobWE26BsAnYI4VTYWIrnlYwnBhG0SKKBnaJTTXHYnfQVPuD75Ba0EM4hZYJUAACAAQAAgAAAAIAAAQ4g25vMvMXXS/I/qsfeZ7RdgajKE3D3sxL0wtKykfFmZXABDwQBAAAAAQDNAgAAAAABAcuZhRB270eyF5uZ9NZkes2JmYC7QzBcSM/GgxYTuikUAAAAAAD9////AgJndM4CAAAAIlEgwgRxu/eg0TNg0SfBd8xyO3SgOq0IBq+cYsfn6aSUGmkA4fUFAAAAACIAICn+8vRBEU+5VfeZTXt8FONmSZDcEXUc88e/6D+SROL/AUBCV2GrTX0G0hgsnYix+yuKPSXrgWcqQJRDLsbzviRinoL43qPokzfBpfyc66J+0GbyQWU+Bt88htzwg3AqQTF3AAAAAAEBcgDh9QUAAAAAaVIhAjY9pkhm1G9ybFB0geUquQMKOzT+pnil4pC3tJC0X2OAIQKW1q44thLR57znb7mb9hJZPubSuAQsrNk5/7aeXmniaSEDC+2bcYNaXdfUW8cvtIpX8qM5bgyuVJ+4P+fwO4J80JRTrgEFaVIhAjY9pkhm1G9ybFB0geUquQMKOzT+pnil4pC3tJC0X2OAIQKW1q44thLR57znb7mb9hJZPubSuAQsrNk5/7aeXmniaSEDC+2bcYNaXdfUW8cvtIpX8qM5bgyuVJ+4P+fwO4J80JRTriIGAjY9pkhm1G9ybFB0geUquQMKOzT+pnil4pC3tJC0X2OAGHObGadUAACAAQAAgAAAAIAAAAAAEQAAACIGApbWrji2EtHnvOdvuZv2Elk+5tK4BCys2Tn/tp5eaeJpGMc6QjZUAACAAQAAgAAAAIAAAAAAEQAAACIGAwvtm3GDWl3X1FvHL7SKV/KjOW4MrlSfuD/n8DuCfNCUGM4hZYJUAACAAQAAgAAAAIAAAAAAEQAAAAABAwgDv/UFAAAAAAEEIgAgkaeXjJOPqXV0taM43yaCh16Fv+TvQ22/sHBWVpJH+DAA",
+      },
+    },
+  ],
+  sentTransaction: [
+    {
+      case: "CPFP on outgoing payment - Spending change output to accelerate own transaction",
+      // This simulates sending Bitcoin with a low fee, then using change output for CPFP
+      // Parent tx: c04265be523006e5394a9a917a852231144000aa9926b42597cec62ea8d3c88b
+      // We're spending output 1 (change output) to create a child transaction
+
+      parentTransaction: {
+        txid: "c04265be523006e5394a9a917a852231144000aa9926b42597cec62ea8d3c88b",
+        hex: "01000000000101cb99851076ef47b2179b99f4d6647acd899980bb43305c48cfc6831613ba29140100000000fdffffff0200e1f50500000000160014650182549b215de6007d286966675c69bc257f881c7cd71700000000220020c7f89d9f73995d9eb8649ba845d5f49586f82fb77a7459dbf08f88a226fe93850400473044022052024c7f6aaf51ca4a3d3ca4ba235d7ba353e280e8eace3368db84d3ca8a23db02207e7aaa36792a45237c7ab5f1c261d5f8ef9335e12dc4e397f1d3145017de5c4d0147304402207db9f2762e022503b3f3af2bc4e1148a24c6167341df347824f892ad1870d342022013a6dcfd0ef04c0472f47a93e209e319d232b394e9467fa1bc979ea1f309639b016952210227c0604bf32cde2ec295801c3f699aac2d81428a9ef21e0b482e1e4061cf97662102a48d032a8d75b42cd7916504c0444fc58f4c9bc91b04f3d4fe91763d324abe192102f6e05ade9cd9226697f997b15c0bc33fc4527b7260751039bb3bc76afc5f022f53ae00000000",
+        fee: 2020, // Parent transaction fee (low fee causing delay)
+        vsize: 188.5,
+      },
+
+      // The parent UTXO - this is output 1 (change output) from the parent transaction
+      // This output belongs to us (it's our change), so we can spend it for CPFP
+      parentUtxo: {
+        txid: "c04265be523006e5394a9a917a852231144000aa9926b42597cec62ea8d3c88b",
+        vout: 1, // Spending output index 1 (our change output)
+        value: "399997980", // Change amount in satoshis (~3.99 BTC)
+        prevTxHex:
+          "01000000000101cb99851076ef47b2179b99f4d6647acd899980bb43305c48cfc6831613ba29140100000000fdffffff0200e1f50500000000160014650182549b215de6007d286966675c69bc257f881c7cd71700000000220020c7f89d9f73995d9eb8649ba845d5f49586f82fb77a7459dbf08f88a226fe93850400473044022052024c7f6aaf51ca4a3d3ca4ba235d7ba353e280e8eace3368db84d3ca8a23db02207e7aaa36792a45237c7ab5f1c261d5f8ef9335e12dc4e397f1d3145017de5c4d0147304402207db9f2762e022503b3f3af2bc4e1148a24c6167341df347824f892ad1870d342022013a6dcfd0ef04c0472f47a93e209e319d232b394e9467fa1bc979ea1f309639b016952210227c0604bf32cde2ec295801c3f699aac2d81428a9ef21e0b482e1e4061cf97662102a48d032a8d75b42cd7916504c0444fc58f4c9bc91b04f3d4fe91763d324abe192102f6e05ade9cd9226697f997b15c0bc33fc4527b7260751039bb3bc76afc5f022f53ae00000000",
+        witnessUtxo: {
+          script: Buffer.from(
+            "1c7cd7170000000069522102832b2469ca66ccb72c01ef6441160c1440d2bdb2f357c1249da8e13c82fd83322102d32d3fb26a64d5817b34bd0e46ef55252ce2888da33428f8950b07c90f43eb682103604468e7783afd6952fedfbb95de5031fdb084c7673c6c9ba69dfbec936ce4eb53ae",
+            "hex",
+          ),
+          value: 399997980,
+        },
+        witnessScript: Buffer.from(
+          "522102832b2469ca66ccb72c01ef6441160c1440d2bdb2f357c1249da8e13c82fd83322102d32d3fb26a64d5817b34bd0e46ef55252ce2888da33428f8950b07c90f43eb682103604468e7783afd6952fedfbb95de5031fdb084c7673c6c9ba69dfbec936ce4eb53ae",
+          "hex",
+        ),
+        bip32Derivations: [
+          {
+            pubkey: Buffer.from(
+              "02832b2469ca66ccb72c01ef6441160c1440d2bdb2f357c1249da8e13c82fd8332",
+              "hex",
+            ),
+            masterFingerprint: Buffer.from("c73a4236", "hex"),
+            path: "m/84'/1'/0'/1/17", // This is a change address (path 1)
+          },
+          {
+            pubkey: Buffer.from(
+              "02d32d3fb26a64d5817b34bd0e46ef55252ce2888da33428f8950b07c90f43eb68",
+              "hex",
+            ),
+            masterFingerprint: Buffer.from("739b19a7", "hex"),
+            path: "m/84'/1'/0'/1/17",
+          },
+          {
+            pubkey: Buffer.from(
+              "03604468e7783afd6952fedfbb95de5031fdb084c7673c6c9ba69dfbec936ce4eb",
+              "hex",
+            ),
+            masterFingerprint: Buffer.from("ce216582", "hex"),
+            path: "m/84'/1'/0'/1/17",
+          },
+        ],
+      },
+
+      availableUtxos: [], // The change output alone provides sufficient value
+
+      spendableOutputIndex: 1, // We're spending output 1 (change) from the parent
+      changeAddress:
+        "bcrt1qjxne0ryn375h2a945vud7f5zsa0gt0lyaapkm0aswpt9dyj8lqcq94eqw4",
+      network: Network.REGTEST,
+      dustThreshold: "546",
+      scriptType: P2WSH,
+      requiredSigners: 2,
+      totalSigners: 3,
+      targetFeeRate: 32.5,
+      globalXpubs: [
+        {
+          xpub: "tpubDCyyVFP5xvLjEtEnUd3ycp8U7m5TZwt8B9q32bBytWEVRaTSWwiWjcR27yJLtgRvJdqbrEupi3vCaDfwZPbL8ViytwYnyeTYeZeDfvyJAMc",
+          masterFingerprint: "739b19a7",
+          path: "m/84'/1'/0'",
+        },
+        {
+          xpub: "tpubDCiNatUPEtNj633QZvvfweoL4VziJe33CVGi4ZKEquVsNmRnwkfqxp4QZMp1GcjcVScyXru3qGna19QH9tTEsqVV7Jf8vgAKTDPFfoYQZZf",
+          masterFingerprint: "c73a4236",
+          path: "m/84'/1'/0'",
+        },
+        {
+          xpub: "tpubDDimkbNa9cUM3y6vTJ39TGGbAENXMHrH81SmY7aQZtVLcAFQSLYtzzj5PpMrfcNx2bnGjtqgPRdqRx6aWudEuqpbBWpJYPdfJQYkKec6JgY",
+          masterFingerprint: "ce216582",
+          path: "m/84'/1'/0'",
+        },
+      ],
+
+      expected: {
+        parentTxid:
+          "8bc8d3a82ec6ce9725b42699aa0040143122857a919a4a39e5063052be6542c0",
+        parentFee: 2020,
+        parentVsize: 188.5,
+        childInputCount: 1, // Only spending the parent change output
+        childOutputCount: 1, // Only one output (consolidating the change)
+        combinedFeeRate: 32.5, // Achieved combined fee rate
+        // The exact PSBT we expect to generate for this CPFP transaction
+        exactPsbt:
+          "cHNidP8B+wQCAAAAAQIEAgAAAAEEAQEBBQEBAQMEAAAAAAEGAQNPAQQ1h88Dgl2SPYAAAAA1gVrVrrCaAW77pvICudYT1OgMKWDHqygcNSGGEkGHtgOdMV/Gaa1omz+62G2Nk86Bp394s033WzYxU10IL4gndhBzmxmnVAAAgAEAAIAAAACATwEENYfPA13Er/mAAAAAXIkZAJ6zR6nZcfefzibOf8yIfgZw/MEBt3mO/wcS3tUC0m1lmogMBUHKndl7pk8FE6bqDneo61acMUMLVwZ3YpYQxzpCNlQAAIABAACAAAAAgE8BBDWHzwPmwZ+cgAAAAKgJSKesi1xqjMGyDjwGyadlp3IKHoSuCeqQobWE26BsAnYI4VTYWIrnlYwnBhG0SKKBnaJTTXHYnfQVPuD75Ba0EM4hZYJUAACAAQAAgAAAAIAAAQ4gi8jTqC7GzpcltCaZqgBAFDEihXqRmko55QYwUr5lQsABDwQBAAAAAQD9ewEBAAAAAAEBy5mFEHbvR7IXm5n01mR6zYmZgLtDMFxIz8aDFhO6KRQBAAAAAP3///8CAOH1BQAAAAAWABRlAYJUmyFd5gB9KGlmZ1xpvCV/iBx81xcAAAAAIgAgx/idn3OZXZ64ZJuoRdX0lYb4L7d6dFnb8I+Ioib+k4UEAEcwRAIgUgJMf2qvUcpKPTykuiNde6NT4oDo6s4zaNuE08qKI9sCIH56qjZ5KkUjfHq18cJh1fjvkzXhLcTjl/HTFFAX3lxNAUcwRAIgfbnydi4CJQOz868rxOEUiiTGFnNB3zR4JPiSrRhw00ICIBOm3P0O8EwEcvR6k+IJ4xnSMrOU6UZ/obyXnqHzCWObAWlSIQInwGBL8yzeLsKVgBw/aZqsLYFCip7yHgtILh5AYc+XZiECpI0DKo11tCzXkWUEwERPxY9Mm8kbBPPU/pF2PTJKvhkhAvbgWt6c2SJml/mXsVwLwz/EUntyYHUQObs7x2r8XwIvU64AAAAAAQFyHHzXFwAAAABpUiECgyskacpmzLcsAe9kQRYMFEDSvbLzV8EknajhPIL9gzIhAtMtP7JqZNWBezS9DkbvVSUs4oiNozQo+JULB8kPQ+toIQNgRGjneDr9aVL+37uV3lAx/bCEx2c8bJumnfvsk2zk61OuAQVpUiECgyskacpmzLcsAe9kQRYMFEDSvbLzV8EknajhPIL9gzIhAtMtP7JqZNWBezS9DkbvVSUs4oiNozQo+JULB8kPQ+toIQNgRGjneDr9aVL+37uV3lAx/bCEx2c8bJumnfvsk2zk61OuIgYC0y0/smpk1YF7NL0ORu9VJSziiI2jNCj4lQsHyQ9D62gYc5sZp1QAAIABAACAAAAAgAEAAAARAAAAIgYCgyskacpmzLcsAe9kQRYMFEDSvbLzV8EknajhPIL9gzIYxzpCNlQAAIABAACAAAAAgAEAAAARAAAAIgYDYERo53g6/WlS/t+7ld5QMf2whMdnPGybpp377JNs5OsYziFlglQAAIABAACAAAAAgAEAAAARAAAAAAEDCHpX1xcAAAAAAQQiACCRp5eMk4+pdXS1ozjfJoKHXoW/5O9Dbb+wcFZWkkf4MAA=",
+      },
+    },
+  ],
+};

--- a/packages/caravan-fees/src/tests/psbtTestCpfp.test.ts
+++ b/packages/caravan-fees/src/tests/psbtTestCpfp.test.ts
@@ -1,0 +1,234 @@
+import { MultisigAddressType } from "@caravan/bitcoin";
+import { PsbtV2 } from "@caravan/psbt";
+import { BigNumber } from "bignumber.js";
+
+import { createCPFPTransaction } from "../cpfp";
+import { TransactionAnalyzer } from "../transactionAnalyzer";
+import {
+  calculateTotalInputValue,
+  calculateTotalOutputValue,
+  reverseHex,
+} from "../utils";
+
+import { cpfpPsbtFixtures } from "./psbtTestCpfp.fixtures";
+
+describe("CPFP PSBT Recreation Tests", () => {
+  describe("Receiving Transaction CPFP", () => {
+    cpfpPsbtFixtures.receivingTransaction.forEach((fixture) => {
+      it(fixture.case, () => {
+        const cpfpPsbtBase64 = createCPFPTransaction({
+          originalTx: fixture.parentTransaction.hex,
+          network: fixture.network,
+          targetFeeRate: fixture.targetFeeRate,
+          absoluteFee: fixture.parentTransaction.fee.toString(),
+          availableInputs: fixture.availableUtxos,
+          requiredSigners: fixture.requiredSigners,
+          totalSigners: fixture.totalSigners,
+          scriptType: fixture.scriptType as MultisigAddressType,
+          dustThreshold: fixture.dustThreshold,
+          spendableOutputIndex: fixture.spendableOutputIndex,
+          parentUtxo: fixture.parentUtxo, //  parent UTXO
+          changeAddress: fixture.changeAddress,
+          globalXpubs: fixture.globalXpubs,
+        });
+
+        const generatedPsbt = new PsbtV2(cpfpPsbtBase64);
+        const expectedPsbt = new PsbtV2(fixture.expected.exactPsbt, true);
+
+        // === STRUCTURAL VERIFICATION ===
+        // Verify the basic transaction structure matches expectations
+
+        expect(generatedPsbt.PSBT_GLOBAL_INPUT_COUNT).toBe(
+          fixture.expected.childInputCount,
+        );
+        expect(generatedPsbt.PSBT_GLOBAL_OUTPUT_COUNT).toBe(
+          fixture.expected.childOutputCount,
+        );
+
+        // === PARENT UTXO VERIFICATION ===
+        // Verify that we're correctly spending from the parent transaction
+
+        expect(reverseHex(generatedPsbt.PSBT_IN_PREVIOUS_TXID[0])).toBe(
+          fixture.expected.parentTxid,
+        );
+        expect(generatedPsbt.PSBT_IN_OUTPUT_INDEX[0]).toBe(
+          fixture.spendableOutputIndex,
+        );
+
+        // === PSBT METADATA VERIFICATION ===
+        // Ensure all necessary signing information is present and correct
+
+        // Witness UTXO data must be present for segwit transactions
+        expect(generatedPsbt.PSBT_IN_WITNESS_UTXO[0]).toBeDefined();
+        expect(generatedPsbt.PSBT_IN_WITNESS_UTXO[0]).not.toBeNull();
+
+        // Witness script is required for P2WSH multisig spending
+        expect(generatedPsbt.PSBT_IN_WITNESS_SCRIPT[0]).toBeDefined();
+        expect(generatedPsbt.PSBT_IN_WITNESS_SCRIPT[0]).not.toBeNull();
+
+        // BIP32 derivations are essential for hardware wallet signing
+        expect(generatedPsbt.PSBT_IN_BIP32_DERIVATION[0]).toBeDefined();
+        expect(generatedPsbt.PSBT_IN_BIP32_DERIVATION[0].length).toBe(
+          fixture.totalSigners,
+        );
+
+        // === GLOBAL XPUB VERIFICATION ===
+        // Verify that global xpubs are included for wallet context
+
+        expect(generatedPsbt.PSBT_GLOBAL_XPUB).toBeDefined();
+        expect(generatedPsbt.PSBT_GLOBAL_XPUB.length).toBe(
+          fixture.globalXpubs.length,
+        );
+
+        fixture.globalXpubs.forEach((expectedXpub, index) => {
+          const psbtXpub = generatedPsbt.PSBT_GLOBAL_XPUB[index];
+          expect(psbtXpub).toBeDefined();
+
+          // Verify the master fingerprint is correctly encoded
+          if (psbtXpub.value) {
+            const valueBuffer = Buffer.from(psbtXpub.value, "hex");
+            const fingerprint = valueBuffer.slice(0, 4).toString("hex");
+            expect(fingerprint).toBe(expectedXpub.masterFingerprint);
+          }
+        });
+
+        // === FEE CALCULATION VERIFICATION ===
+        // Verify that the CPFP achieves the target combined fee rate
+
+        const totalInputAmount = calculateTotalInputValue(generatedPsbt);
+        const totalOutputAmount = calculateTotalOutputValue(generatedPsbt);
+        const childFee = totalInputAmount.minus(totalOutputAmount);
+
+        // Calculate combined fee rate (parent + child fees over combined vsize)
+        const parentFee = new BigNumber(fixture.expected.parentFee);
+        const combinedFee = parentFee.plus(childFee);
+        const combinedVsize = fixture.expected.parentVsize + 116; // Estimated child vsize
+        const combinedFeeRate = combinedFee.dividedBy(combinedVsize);
+
+        // Verify we achieved approximately the target fee rate
+        expect(combinedFeeRate.toNumber()).toBeCloseTo(
+          fixture.expected.combinedFeeRate,
+          1,
+        );
+
+        // === EXACT PSBT BINARY VERIFICATION ===
+        // This is the most important test - verify exact PSBT binary output
+        // This catches any subtle changes in PSBT generation that might break compatibility
+
+        expect(generatedPsbt.serialize("base64")).toBe(
+          expectedPsbt.serialize("base64"),
+        );
+      });
+    });
+  });
+
+  describe("Sent Transaction CPFP", () => {
+    cpfpPsbtFixtures.sentTransaction.forEach((fixture) => {
+      it(fixture.case, () => {
+        const cpfpPsbtBase64 = createCPFPTransaction({
+          originalTx: fixture.parentTransaction.hex,
+          network: fixture.network,
+          targetFeeRate: fixture.targetFeeRate,
+          absoluteFee: fixture.parentTransaction.fee.toString(),
+          availableInputs: fixture.availableUtxos,
+          requiredSigners: fixture.requiredSigners,
+          totalSigners: fixture.totalSigners,
+          scriptType: fixture.scriptType as MultisigAddressType,
+          dustThreshold: fixture.dustThreshold,
+          spendableOutputIndex: fixture.spendableOutputIndex,
+          parentUtxo: fixture.parentUtxo, // The change output
+          changeAddress: fixture.changeAddress,
+          globalXpubs: fixture.globalXpubs,
+        });
+
+        const generatedPsbt = new PsbtV2(cpfpPsbtBase64);
+        const expectedPsbt = new PsbtV2(fixture.expected.exactPsbt, true);
+
+        // === CHANGE OUTPUT SPECIFIC VERIFICATION ===
+        // When spending change outputs, we need to verify the derivation path is correct
+
+        expect(reverseHex(generatedPsbt.PSBT_IN_PREVIOUS_TXID[0])).toBe(
+          fixture.expected.parentTxid,
+        );
+        expect(generatedPsbt.PSBT_IN_OUTPUT_INDEX[0]).toBe(
+          fixture.spendableOutputIndex,
+        );
+
+        // Verify this is indeed a change output (derivation path should include '/1/')
+        // Change addresses use path m/84'/1'/0'/1/* while receiving addresses use m/84'/1'/0'/0/*
+        const bip32Derivation = generatedPsbt.PSBT_IN_BIP32_DERIVATION[0][0];
+        expect(bip32Derivation).toBeDefined();
+
+        // The derivation should indicate this is a change address
+        // (We can't easily decode the path here, but the fixture verification ensures correctness)
+
+        // === CONSOLIDATION VERIFICATION ===
+        // CPFP on sent transactions often consolidates change back to a single output
+
+        expect(generatedPsbt.PSBT_GLOBAL_INPUT_COUNT).toBe(
+          fixture.expected.childInputCount,
+        );
+        expect(generatedPsbt.PSBT_GLOBAL_OUTPUT_COUNT).toBe(
+          fixture.expected.childOutputCount,
+        );
+
+        // === EXACT BINARY MATCH ===
+        // Final verification that we generate the exact expected PSBT
+
+        expect(generatedPsbt.serialize("base64")).toBe(
+          expectedPsbt.serialize("base64"),
+        );
+      });
+    });
+  });
+
+  describe("Transaction Analysis Integration", () => {
+    it("should properly analyze CPFP suitability for receiving transactions", () => {
+      const fixture = cpfpPsbtFixtures.receivingTransaction[0];
+
+      // Analyze the parent transaction to verify CPFP is recommended
+      const analyzer = new TransactionAnalyzer({
+        txHex: fixture.parentTransaction.hex,
+        network: fixture.network,
+        targetFeeRate: fixture.targetFeeRate,
+        absoluteFee: fixture.parentTransaction.fee.toString(),
+        availableUtxos: [fixture.parentUtxo], // Include the parent UTXO
+        requiredSigners: fixture.requiredSigners,
+        totalSigners: fixture.totalSigners,
+        addressType: fixture.scriptType as MultisigAddressType,
+        changeOutputIndex: fixture.spendableOutputIndex,
+      });
+
+      const analysis = analyzer.analyze();
+
+      // Should recommend CPFP for low-fee transactions
+      expect(analysis.canCPFP).toBe(true);
+    });
+
+    it("should handle sent transaction analysis correctly", () => {
+      const fixture = cpfpPsbtFixtures.sentTransaction[0];
+
+      const analyzer = new TransactionAnalyzer({
+        txHex: fixture.parentTransaction.hex,
+        network: fixture.network,
+        targetFeeRate: fixture.targetFeeRate,
+        absoluteFee: fixture.parentTransaction.fee.toString(),
+        availableUtxos: [fixture.parentUtxo],
+        requiredSigners: fixture.requiredSigners,
+        totalSigners: fixture.totalSigners,
+        addressType: fixture.scriptType as MultisigAddressType,
+        changeOutputIndex: fixture.spendableOutputIndex,
+      });
+
+      const analysis = analyzer.analyze();
+
+      // Should identify the change output as spendable
+      expect(analysis.canCPFP).toBe(true);
+
+      // Should calculate appropriate package size
+      expect(analyzer.CPFPPackageSize).toBeGreaterThan(
+        fixture.expected.parentVsize,
+      );
+    });
+  });
+});

--- a/packages/caravan-fees/src/tests/psbtTestCpfp.test.ts
+++ b/packages/caravan-fees/src/tests/psbtTestCpfp.test.ts
@@ -14,221 +14,217 @@ import { cpfpPsbtFixtures } from "./psbtTestCpfp.fixtures";
 
 describe("CPFP PSBT Recreation Tests", () => {
   describe("Receiving Transaction CPFP", () => {
-    cpfpPsbtFixtures.receivingTransaction.forEach((fixture) => {
-      it(fixture.case, () => {
-        const cpfpPsbtBase64 = createCPFPTransaction({
-          originalTx: fixture.parentTransaction.hex,
-          network: fixture.network,
-          targetFeeRate: fixture.targetFeeRate,
-          absoluteFee: fixture.parentTransaction.fee.toString(),
-          availableInputs: fixture.availableUtxos,
-          requiredSigners: fixture.requiredSigners,
-          totalSigners: fixture.totalSigners,
-          scriptType: fixture.scriptType as MultisigAddressType,
-          dustThreshold: fixture.dustThreshold,
-          spendableOutputIndex: fixture.spendableOutputIndex,
-          parentUtxo: fixture.parentUtxo, //  parent UTXO
-          changeAddress: fixture.changeAddress,
-          globalXpubs: fixture.globalXpubs,
-        });
-
-        const generatedPsbt = new PsbtV2(cpfpPsbtBase64);
-        const expectedPsbt = new PsbtV2(fixture.expected.exactPsbt, true);
-
-        // === STRUCTURAL VERIFICATION ===
-        // Verify the basic transaction structure matches expectations
-
-        expect(generatedPsbt.PSBT_GLOBAL_INPUT_COUNT).toBe(
-          fixture.expected.childInputCount,
-        );
-        expect(generatedPsbt.PSBT_GLOBAL_OUTPUT_COUNT).toBe(
-          fixture.expected.childOutputCount,
-        );
-
-        // === PARENT UTXO VERIFICATION ===
-        // Verify that we're correctly spending from the parent transaction
-
-        expect(reverseHex(generatedPsbt.PSBT_IN_PREVIOUS_TXID[0])).toBe(
-          fixture.expected.parentTxid,
-        );
-        expect(generatedPsbt.PSBT_IN_OUTPUT_INDEX[0]).toBe(
-          fixture.spendableOutputIndex,
-        );
-
-        // === PSBT METADATA VERIFICATION ===
-        // Ensure all necessary signing information is present and correct
-
-        // Witness UTXO data must be present for segwit transactions
-        expect(generatedPsbt.PSBT_IN_WITNESS_UTXO[0]).toBeDefined();
-        expect(generatedPsbt.PSBT_IN_WITNESS_UTXO[0]).not.toBeNull();
-
-        // Witness script is required for P2WSH multisig spending
-        expect(generatedPsbt.PSBT_IN_WITNESS_SCRIPT[0]).toBeDefined();
-        expect(generatedPsbt.PSBT_IN_WITNESS_SCRIPT[0]).not.toBeNull();
-
-        // BIP32 derivations are essential for hardware wallet signing
-        expect(generatedPsbt.PSBT_IN_BIP32_DERIVATION[0]).toBeDefined();
-        expect(generatedPsbt.PSBT_IN_BIP32_DERIVATION[0].length).toBe(
-          fixture.totalSigners,
-        );
-
-        // === GLOBAL XPUB VERIFICATION ===
-        // Verify that global xpubs are included for wallet context
-
-        expect(generatedPsbt.PSBT_GLOBAL_XPUB).toBeDefined();
-        expect(generatedPsbt.PSBT_GLOBAL_XPUB.length).toBe(
-          fixture.globalXpubs.length,
-        );
-
-        fixture.globalXpubs.forEach((expectedXpub, index) => {
-          const psbtXpub = generatedPsbt.PSBT_GLOBAL_XPUB[index];
-          expect(psbtXpub).toBeDefined();
-
-          // Verify the master fingerprint is correctly encoded
-          if (psbtXpub.value) {
-            const valueBuffer = Buffer.from(psbtXpub.value, "hex");
-            const fingerprint = valueBuffer.slice(0, 4).toString("hex");
-            expect(fingerprint).toBe(expectedXpub.masterFingerprint);
-          }
-        });
-
-        // === FEE CALCULATION VERIFICATION ===
-        // Verify that the CPFP achieves the target combined fee rate
-
-        const totalInputAmount = calculateTotalInputValue(generatedPsbt);
-        const totalOutputAmount = calculateTotalOutputValue(generatedPsbt);
-        const childFee = totalInputAmount.minus(totalOutputAmount);
-
-        // Calculate combined fee rate (parent + child fees over combined vsize)
-        const parentFee = new BigNumber(fixture.expected.parentFee);
-        const combinedFee = parentFee.plus(childFee);
-        const combinedVsize = fixture.expected.parentVsize + 116; // Estimated child vsize
-        const combinedFeeRate = combinedFee.dividedBy(combinedVsize);
-
-        // Verify we achieved approximately the target fee rate
-        expect(combinedFeeRate.toNumber()).toBeCloseTo(
-          fixture.expected.combinedFeeRate,
-          1,
-        );
-
-        // === EXACT PSBT BINARY VERIFICATION ===
-        // This is the most important test - verify exact PSBT binary output
-        // This catches any subtle changes in PSBT generation that might break compatibility
-
-        expect(generatedPsbt.serialize("base64")).toBe(
-          expectedPsbt.serialize("base64"),
-        );
-      });
-    });
-  });
-
-  describe("Sent Transaction CPFP", () => {
-    cpfpPsbtFixtures.sentTransaction.forEach((fixture) => {
-      it(fixture.case, () => {
-        const cpfpPsbtBase64 = createCPFPTransaction({
-          originalTx: fixture.parentTransaction.hex,
-          network: fixture.network,
-          targetFeeRate: fixture.targetFeeRate,
-          absoluteFee: fixture.parentTransaction.fee.toString(),
-          availableInputs: fixture.availableUtxos,
-          requiredSigners: fixture.requiredSigners,
-          totalSigners: fixture.totalSigners,
-          scriptType: fixture.scriptType as MultisigAddressType,
-          dustThreshold: fixture.dustThreshold,
-          spendableOutputIndex: fixture.spendableOutputIndex,
-          parentUtxo: fixture.parentUtxo, // The change output
-          changeAddress: fixture.changeAddress,
-          globalXpubs: fixture.globalXpubs,
-        });
-
-        const generatedPsbt = new PsbtV2(cpfpPsbtBase64);
-        const expectedPsbt = new PsbtV2(fixture.expected.exactPsbt, true);
-
-        // === CHANGE OUTPUT SPECIFIC VERIFICATION ===
-        // When spending change outputs, we need to verify the derivation path is correct
-
-        expect(reverseHex(generatedPsbt.PSBT_IN_PREVIOUS_TXID[0])).toBe(
-          fixture.expected.parentTxid,
-        );
-        expect(generatedPsbt.PSBT_IN_OUTPUT_INDEX[0]).toBe(
-          fixture.spendableOutputIndex,
-        );
-
-        // Verify this is indeed a change output (derivation path should include '/1/')
-        // Change addresses use path m/84'/1'/0'/1/* while receiving addresses use m/84'/1'/0'/0/*
-        const bip32Derivation = generatedPsbt.PSBT_IN_BIP32_DERIVATION[0][0];
-        expect(bip32Derivation).toBeDefined();
-
-        // The derivation should indicate this is a change address
-        // (We can't easily decode the path here, but the fixture verification ensures correctness)
-
-        // === CONSOLIDATION VERIFICATION ===
-        // CPFP on sent transactions often consolidates change back to a single output
-
-        expect(generatedPsbt.PSBT_GLOBAL_INPUT_COUNT).toBe(
-          fixture.expected.childInputCount,
-        );
-        expect(generatedPsbt.PSBT_GLOBAL_OUTPUT_COUNT).toBe(
-          fixture.expected.childOutputCount,
-        );
-
-        // === EXACT BINARY MATCH ===
-        // Final verification that we generate the exact expected PSBT
-
-        expect(generatedPsbt.serialize("base64")).toBe(
-          expectedPsbt.serialize("base64"),
-        );
-      });
-    });
-  });
-
-  describe("Transaction Analysis Integration", () => {
-    it("should properly analyze CPFP suitability for receiving transactions", () => {
-      const fixture = cpfpPsbtFixtures.receivingTransaction[0];
-
-      // Analyze the parent transaction to verify CPFP is recommended
-      const analyzer = new TransactionAnalyzer({
-        txHex: fixture.parentTransaction.hex,
+    it.each(cpfpPsbtFixtures.receivingTransaction)("$case", (fixture) => {
+      const cpfpPsbtBase64 = createCPFPTransaction({
+        originalTx: fixture.parentTransaction.hex,
         network: fixture.network,
         targetFeeRate: fixture.targetFeeRate,
         absoluteFee: fixture.parentTransaction.fee.toString(),
-        availableUtxos: [fixture.parentUtxo], // Include the parent UTXO
+        availableInputs: fixture.availableUtxos,
         requiredSigners: fixture.requiredSigners,
         totalSigners: fixture.totalSigners,
-        addressType: fixture.scriptType as MultisigAddressType,
-        changeOutputIndex: fixture.spendableOutputIndex,
+        scriptType: fixture.scriptType as MultisigAddressType,
+        dustThreshold: fixture.dustThreshold,
+        spendableOutputIndex: fixture.spendableOutputIndex,
+        parentUtxo: fixture.parentUtxo, //  parent UTXO
+        changeAddress: fixture.changeAddress,
+        globalXpubs: fixture.globalXpubs,
       });
 
-      const analysis = analyzer.analyze();
+      const generatedPsbt = new PsbtV2(cpfpPsbtBase64);
+      const expectedPsbt = new PsbtV2(fixture.expected.exactPsbt, true);
 
-      // Should recommend CPFP for low-fee transactions
-      expect(analysis.canCPFP).toBe(true);
-    });
+      // === STRUCTURAL VERIFICATION ===
+      // Verify the basic transaction structure matches expectations
 
-    it("should handle sent transaction analysis correctly", () => {
-      const fixture = cpfpPsbtFixtures.sentTransaction[0];
+      expect(generatedPsbt.PSBT_GLOBAL_INPUT_COUNT).toBe(
+        fixture.expected.childInputCount,
+      );
+      expect(generatedPsbt.PSBT_GLOBAL_OUTPUT_COUNT).toBe(
+        fixture.expected.childOutputCount,
+      );
 
-      const analyzer = new TransactionAnalyzer({
-        txHex: fixture.parentTransaction.hex,
-        network: fixture.network,
-        targetFeeRate: fixture.targetFeeRate,
-        absoluteFee: fixture.parentTransaction.fee.toString(),
-        availableUtxos: [fixture.parentUtxo],
-        requiredSigners: fixture.requiredSigners,
-        totalSigners: fixture.totalSigners,
-        addressType: fixture.scriptType as MultisigAddressType,
-        changeOutputIndex: fixture.spendableOutputIndex,
+      // === PARENT UTXO VERIFICATION ===
+      // Verify that we're correctly spending from the parent transaction
+
+      expect(reverseHex(generatedPsbt.PSBT_IN_PREVIOUS_TXID[0])).toBe(
+        fixture.expected.parentTxid,
+      );
+      expect(generatedPsbt.PSBT_IN_OUTPUT_INDEX[0]).toBe(
+        fixture.spendableOutputIndex,
+      );
+
+      // === PSBT METADATA VERIFICATION ===
+      // Ensure all necessary signing information is present and correct
+
+      // Witness UTXO data must be present for segwit transactions
+      expect(generatedPsbt.PSBT_IN_WITNESS_UTXO[0]).toBeDefined();
+      expect(generatedPsbt.PSBT_IN_WITNESS_UTXO[0]).not.toBeNull();
+
+      // Witness script is required for P2WSH multisig spending
+      expect(generatedPsbt.PSBT_IN_WITNESS_SCRIPT[0]).toBeDefined();
+      expect(generatedPsbt.PSBT_IN_WITNESS_SCRIPT[0]).not.toBeNull();
+
+      // BIP32 derivations are essential for hardware wallet signing
+      expect(generatedPsbt.PSBT_IN_BIP32_DERIVATION[0]).toBeDefined();
+      expect(generatedPsbt.PSBT_IN_BIP32_DERIVATION[0].length).toBe(
+        fixture.totalSigners,
+      );
+
+      // === GLOBAL XPUB VERIFICATION ===
+      // Verify that global xpubs are included for wallet context
+
+      expect(generatedPsbt.PSBT_GLOBAL_XPUB).toBeDefined();
+      expect(generatedPsbt.PSBT_GLOBAL_XPUB.length).toBe(
+        fixture.globalXpubs.length,
+      );
+
+      fixture.globalXpubs.forEach((expectedXpub, index) => {
+        const psbtXpub = generatedPsbt.PSBT_GLOBAL_XPUB[index];
+        expect(psbtXpub).toBeDefined();
+
+        // Verify the master fingerprint is correctly encoded
+        if (psbtXpub.value) {
+          const valueBuffer = Buffer.from(psbtXpub.value, "hex");
+          const fingerprint = valueBuffer.slice(0, 4).toString("hex");
+          expect(fingerprint).toBe(expectedXpub.masterFingerprint);
+        }
       });
 
-      const analysis = analyzer.analyze();
+      // === FEE CALCULATION VERIFICATION ===
+      // Verify that the CPFP achieves the target combined fee rate
 
-      // Should identify the change output as spendable
-      expect(analysis.canCPFP).toBe(true);
+      const totalInputAmount = calculateTotalInputValue(generatedPsbt);
+      const totalOutputAmount = calculateTotalOutputValue(generatedPsbt);
+      const childFee = totalInputAmount.minus(totalOutputAmount);
 
-      // Should calculate appropriate package size
-      expect(analyzer.CPFPPackageSize).toBeGreaterThan(
-        fixture.expected.parentVsize,
+      // Calculate combined fee rate (parent + child fees over combined vsize)
+      const parentFee = new BigNumber(fixture.expected.parentFee);
+      const combinedFee = parentFee.plus(childFee);
+      const combinedVsize = fixture.expected.parentVsize + 116; // Estimated child vsize
+      const combinedFeeRate = combinedFee.dividedBy(combinedVsize);
+
+      // Verify we achieved approximately the target fee rate
+      expect(combinedFeeRate.toNumber()).toBeCloseTo(
+        fixture.expected.combinedFeeRate,
+        1,
+      );
+
+      // === EXACT PSBT BINARY VERIFICATION ===
+      // This is the most important test - verify exact PSBT binary output
+      // This catches any subtle changes in PSBT generation that might break compatibility
+
+      expect(generatedPsbt.serialize("base64")).toBe(
+        expectedPsbt.serialize("base64"),
       );
     });
+  });
+});
+
+describe("Sent Transaction CPFP", () => {
+  it.each(cpfpPsbtFixtures.sentTransaction)("$case", (fixture) => {
+    const cpfpPsbtBase64 = createCPFPTransaction({
+      originalTx: fixture.parentTransaction.hex,
+      network: fixture.network,
+      targetFeeRate: fixture.targetFeeRate,
+      absoluteFee: fixture.parentTransaction.fee.toString(),
+      availableInputs: fixture.availableUtxos,
+      requiredSigners: fixture.requiredSigners,
+      totalSigners: fixture.totalSigners,
+      scriptType: fixture.scriptType as MultisigAddressType,
+      dustThreshold: fixture.dustThreshold,
+      spendableOutputIndex: fixture.spendableOutputIndex,
+      parentUtxo: fixture.parentUtxo, // The change output
+      changeAddress: fixture.changeAddress,
+      globalXpubs: fixture.globalXpubs,
+    });
+
+    const generatedPsbt = new PsbtV2(cpfpPsbtBase64);
+    const expectedPsbt = new PsbtV2(fixture.expected.exactPsbt, true);
+
+    // === CHANGE OUTPUT SPECIFIC VERIFICATION ===
+    // When spending change outputs, we need to verify the derivation path is correct
+
+    expect(reverseHex(generatedPsbt.PSBT_IN_PREVIOUS_TXID[0])).toBe(
+      fixture.expected.parentTxid,
+    );
+    expect(generatedPsbt.PSBT_IN_OUTPUT_INDEX[0]).toBe(
+      fixture.spendableOutputIndex,
+    );
+
+    // Verify this is indeed a change output (derivation path should include '/1/')
+    // Change addresses use path m/84'/1'/0'/1/* while receiving addresses use m/84'/1'/0'/0/*
+    const bip32Derivation = generatedPsbt.PSBT_IN_BIP32_DERIVATION[0][0];
+    expect(bip32Derivation).toBeDefined();
+
+    // The derivation should indicate this is a change address
+    // (We can't easily decode the path here, but the fixture verification ensures correctness)
+
+    // === CONSOLIDATION VERIFICATION ===
+    // CPFP on sent transactions often consolidates change back to a single output
+
+    expect(generatedPsbt.PSBT_GLOBAL_INPUT_COUNT).toBe(
+      fixture.expected.childInputCount,
+    );
+    expect(generatedPsbt.PSBT_GLOBAL_OUTPUT_COUNT).toBe(
+      fixture.expected.childOutputCount,
+    );
+
+    // === EXACT BINARY MATCH ===
+    // Final verification that we generate the exact expected PSBT
+
+    expect(generatedPsbt.serialize("base64")).toBe(
+      expectedPsbt.serialize("base64"),
+    );
+  });
+});
+
+describe("Transaction Analysis Integration", () => {
+  it("should properly analyze CPFP suitability for receiving transactions", () => {
+    const fixture = cpfpPsbtFixtures.receivingTransaction[0];
+
+    // Analyze the parent transaction to verify CPFP is recommended
+    const analyzer = new TransactionAnalyzer({
+      txHex: fixture.parentTransaction.hex,
+      network: fixture.network,
+      targetFeeRate: fixture.targetFeeRate,
+      absoluteFee: fixture.parentTransaction.fee.toString(),
+      availableUtxos: [fixture.parentUtxo], // Include the parent UTXO
+      requiredSigners: fixture.requiredSigners,
+      totalSigners: fixture.totalSigners,
+      addressType: fixture.scriptType as MultisigAddressType,
+      changeOutputIndex: fixture.spendableOutputIndex,
+    });
+
+    const analysis = analyzer.analyze();
+
+    // Should recommend CPFP for low-fee transactions
+    expect(analysis.canCPFP).toBe(true);
+  });
+
+  it("should handle sent transaction analysis correctly", () => {
+    const fixture = cpfpPsbtFixtures.sentTransaction[0];
+
+    const analyzer = new TransactionAnalyzer({
+      txHex: fixture.parentTransaction.hex,
+      network: fixture.network,
+      targetFeeRate: fixture.targetFeeRate,
+      absoluteFee: fixture.parentTransaction.fee.toString(),
+      availableUtxos: [fixture.parentUtxo],
+      requiredSigners: fixture.requiredSigners,
+      totalSigners: fixture.totalSigners,
+      addressType: fixture.scriptType as MultisigAddressType,
+      changeOutputIndex: fixture.spendableOutputIndex,
+    });
+
+    const analysis = analyzer.analyze();
+
+    // Should identify the change output as spendable
+    expect(analysis.canCPFP).toBe(true);
+
+    // Should calculate appropriate package size
+    expect(analyzer.CPFPPackageSize).toBeGreaterThan(
+      fixture.expected.parentVsize,
+    );
   });
 });

--- a/packages/caravan-fees/src/types.ts
+++ b/packages/caravan-fees/src/types.ts
@@ -533,6 +533,17 @@ export interface CPFPOptions {
   spendableOutputIndex: number;
 
   /**
+   * The parent output UTXO with complete PSBT metadata.
+   * This UTXO represents the output from the parent transaction that will be spent
+   * in the child transaction. It must include all necessary signing information
+   * (scripts, derivation paths, etc.) for proper PSBT construction.
+   *
+   * This should be created using wallet-specific logic that can reconstruct
+   * the full UTXO metadata from the transaction output.
+   */
+  parentUtxo: UTXO;
+
+  /**
    * The address where any excess funds (change) will be sent in the child transaction.
    */
   changeAddress: string;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Patch - Added parentUtxo parameter to CPFP transaction creation

**Issue Number:**
Fixes N/A

**Snapshots/Videos:**
N/A -
**If relevant, did you update the documentation?**
Updated TSDoc comments in the createCPFPTransaction function and CPFPOptions interface

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Problem:** 
The existing CPFP implementation in `@caravan/fees` had a critical limitation - it attempted to create a basic UTXO from the parent transaction output using only `createOutputScript()`, but this approach was missing essential PSBT metadata required for proper multisig transaction signing (witnessScript, redeemScript, bip32Derivations, etc.).

**Solution:**
- Modified `CPFPOptions` interface to require a `parentUtxo` parameter with complete PSBT metadata
- Updated `createCPFPTransaction()` to use the enriched parent UTXO instead of creating a basic one
- Added comprehensive validation to ensure the parent UTXO matches the expected output and contains all required PSBT fields
- This allows wallet implementations (like Caravan coordinator) to provide their own UTXO enrichment logic while keeping the fees package generic

**Benefits:**
- Enables proper PSBT creation for CPFP transactions with all necessary signing metadata
- Maintains separation of concerns - fees package handles transaction logic, wallet handles metadata enrichment  
- Provides clear error messages when parent UTXO validation fails
- Keeps the fees package generic while supporting complex multisig scenarios

**Does this PR introduce a breaking change?**
Yes - The `CPFPOptions` interface now requires a `parentUtxo` parameter. Existing code calling `createCPFPTransaction()` will need to provide a fully enriched parent UTXO with complete PSBT metadata.

**Migration path:** Callers need to reconstruct the parent transaction output as a complete UTXO with witnessUtxo/nonWitnessUtxo, bip32Derivations, and appropriate scripts before calling the function.

## Checklist
- [x] I have tested my changes thoroughly.
- [x] I have added or updated tests to cover my changes (if applicable).
- [x] I have verified that test coverage meets or exceeds 95% (if applicable).
- [x] I have run the test suite locally, and all tests pass.
- [x] I have written tests for all new changes/features
- [x] I have followed the project's coding style and conventions.
- [ ] I have created a changeset to document my changes (`` npm run changeset ``)


**Have you read the [contributing guide](https://github.com/caravan-bitcoin/caravan/blob/main/apps/coordinator/CONTRIBUTING.md)?**
Yes