### PR TITLE
fix: break SliceDetails tabs and render them as needed + error handli…

### DIFF
--- a/apps/coordinator/src/components/Slices/SliceDetails.jsx
+++ b/apps/coordinator/src/components/Slices/SliceDetails.jsx
@@ -75,7 +75,9 @@ const SliceDetails = ({ slice, client, network }) => {
   const classes = useStyles();
 
   const handleChange = (_e, newIndex) => setTabIndex(newIndex);
-  const tabs = [
+
+  // Base tabs that are always present
+  const baseTabs = [
     {
       tab: {
         label: "Redeem Script",
@@ -98,10 +100,15 @@ const SliceDetails = ({ slice, client, network }) => {
         </div>
       ),
     },
-    {
+  ];
+
+  const conditionalTabs = [];
+
+  // Only add UTXOs tab if there's a balance , we need this as if we render this in receive tab react does not play well and we get react stack pop issues
+  if (slice.balanceSats.isGreaterThan(0)) {
+    conditionalTabs.push({
       tab: {
         label: "UTXOs",
-        disabled: !slice.balanceSats.isGreaterThan(0),
       },
       panel: (
         <UTXOSet
@@ -110,11 +117,14 @@ const SliceDetails = ({ slice, client, network }) => {
           showSelection={false}
         />
       ),
-    },
-    {
+    });
+  }
+
+  // Watch Address tab (only for private clients)
+  if (client.type === "private") {
+    conditionalTabs.push({
       tab: {
         label: "Watch Address",
-        disabled: client.type !== "private",
       },
       panel: (
         <div>
@@ -131,8 +141,11 @@ const SliceDetails = ({ slice, client, network }) => {
           </Box>
         </div>
       ),
-    },
-  ];
+    });
+  }
+
+  // Combine all tabs
+  const tabs = [...baseTabs, ...conditionalTabs];
 
   return (
     <Grid container className={classes.root}>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Issue Number:**
Fixes #374 

**Summary**

This PR resolves React context stack errors ("Unexpected Fiber popped" in Chrome, missing `textColor` properties in Firefox/Safari) that occurred when expanding address details in the Receive tab.

**Root Cause Analysis:**

The issue was tied to the dust status calculation logic in the `DustChip` component. In the **Receive tab**, we're dealing with fresh UTXOs that haven't been analyzed yet, so we can't calculate their dust status. The health package's `WasteMetrics.calculateDustLimits()` method was returning `null` or `undefined` values, which caused the following problematic code path:

```javascript
// Before fix - caused undefined comparisons
if (amountSats <= lowerLimit) {        // lowerLimit could be undefined
  color = "error";
  label = "Dust";
} else if (amountSats > lowerLimit && amountSats <= upperLimit) { // undefined comparisons
  color = "warning";
  label = "Warning";
}
```

When `lowerLimit` and `upperLimit` were undefined, the MUI `Chip` component received invalid props, causing React's reconciliation process to fail and corrupting the context stack.

**Testing:**
- Verified fix resolves Chrome context stack errors
- Confirmed Firefox/Safari no longer show MUI prop warnings
- Address expansion in Receive tab now works correctly across all browsers

<img width="1466" height="871" alt="Screenshot 2025-09-02 at 23 28 40" src="https://github.com/user-attachments/assets/078860b9-d1ec-4f2a-a3db-f322a2d43b67" />


**Does this PR introduce a breaking change?**
No

## Checklist
- [x] I have tested my changes thoroughly.
- [x] I have followed the project's coding style and conventions.
- [x] I have created a changeset to document my changes