### PR TITLE
feat: addedd address verification

### DIFF
--- a/apps/coordinator/src/components/BCUR2/DescriptorQRCodes.tsx
+++ b/apps/coordinator/src/components/BCUR2/DescriptorQRCodes.tsx
@@ -1,0 +1,170 @@
+import React, { useState, useEffect, useRef } from "react";
+import {
+  Box,
+  Typography,
+  CircularProgress,
+  Button,
+  ButtonGroup,
+} from "@mui/material";
+// @ts-expect-error - qrcode.react doesn't have TypeScript declarations
+import QRCode from "qrcode.react";
+import { encodeDescriptors } from "@caravan/descriptors";
+
+interface DescriptorQRCodesProps {
+  multisigConfig: any; // Use any to avoid strict type checking since the config comes from various sources
+  onDescriptorsGenerated?: (descriptors: {
+    change: string;
+    receive: string;
+  }) => void;
+}
+
+interface Descriptors {
+  change: string;
+  receive: string;
+}
+
+/**
+ * Component to display descriptor QR codes using the same encodeDescriptors function as the wallet page
+ * Shows both receive and change descriptor QR codes with toggle buttons
+ */
+const DescriptorQRCodes: React.FC<DescriptorQRCodesProps> = ({
+  multisigConfig,
+  onDescriptorsGenerated,
+}) => {
+  const [descriptors, setDescriptors] = useState<Descriptors>({
+    change: "",
+    receive: "",
+  });
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedType, setSelectedType] = useState<"receive" | "change">(
+    "receive",
+  );
+
+  // Use ref to track if we've already generated descriptors
+  const hasGeneratedRef = useRef(false);
+  const configStringRef = useRef("");
+
+  useEffect(() => {
+    const generateDescriptors = async () => {
+      try {
+        // Stringify config to check if it actually changed
+        const configString = JSON.stringify(multisigConfig);
+
+        // Skip if we already generated for this exact config
+        if (
+          hasGeneratedRef.current &&
+          configStringRef.current === configString
+        ) {
+          return;
+        }
+
+        configStringRef.current = configString;
+        setLoading(true);
+        setError(null);
+
+        console.log("Generating descriptors with config:", multisigConfig);
+        const descriptors = await encodeDescriptors(multisigConfig);
+
+        setDescriptors(descriptors);
+        setLoading(false);
+        hasGeneratedRef.current = true;
+
+        // Notify parent component
+        if (onDescriptorsGenerated) {
+          onDescriptorsGenerated(descriptors);
+        }
+      } catch (error: any) {
+        console.error("Error generating descriptors:", error);
+        setLoading(false);
+        setError(error.message);
+        setDescriptors({ change: "", receive: "" });
+      }
+    };
+
+    if (multisigConfig) {
+      generateDescriptors();
+    }
+  }, [multisigConfig, onDescriptorsGenerated]);
+
+  if (loading) {
+    return (
+      <Box mb={3}>
+        <Typography variant="h6" gutterBottom color="primary">
+          Generating Wallet Descriptors...
+        </Typography>
+        <CircularProgress size={40} />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box mb={3}>
+        <Typography variant="h6" gutterBottom color="error">
+          Error Generating Descriptors
+        </Typography>
+        <Typography variant="body2" color="error">
+          {error}
+        </Typography>
+      </Box>
+    );
+  }
+
+  const currentDescriptor =
+    selectedType === "receive" ? descriptors.receive : descriptors.change;
+
+  return (
+    <Box mb={3}>
+      {/* Step 2: Wallet Descriptor with toggle */}
+      <Typography variant="h6" gutterBottom color="primary">
+        Step 2: Wallet Descriptor QR Code
+      </Typography>
+
+      {/* Button group to toggle between receive and change */}
+      <Box mb={2}>
+        <ButtonGroup variant="outlined" size="small">
+          <Button
+            variant={selectedType === "receive" ? "contained" : "outlined"}
+            onClick={() => setSelectedType("receive")}
+          >
+            Receive Addresses
+          </Button>
+          <Button
+            variant={selectedType === "change" ? "contained" : "outlined"}
+            onClick={() => setSelectedType("change")}
+          >
+            Change Addresses
+          </Button>
+        </ButtonGroup>
+      </Box>
+
+      {currentDescriptor && (
+        <>
+          <Box border={1} borderColor="grey.300" p={2} borderRadius={2}>
+            <QRCode value={currentDescriptor} size={300} level="M" />
+          </Box>
+          <Typography
+            variant="caption"
+            color="textSecondary"
+            mt={1}
+            display="block"
+          >
+            Scan this {selectedType} descriptor with your hardware wallet
+          </Typography>
+          <Typography
+            variant="body2"
+            color="textSecondary"
+            mt={1}
+            style={{ wordBreak: "break-all", fontSize: "0.75rem" }}
+          >
+            {selectedType === "receive" ? "Receive" : "Change"}:{" "}
+            <code>{currentDescriptor}</code>
+          </Typography>
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default DescriptorQRCodes;

--- a/apps/coordinator/src/components/BCUR2/index.ts
+++ b/apps/coordinator/src/components/BCUR2/index.ts
@@ -1,2 +1,3 @@
 export { default as BCUR2Reader } from "./BCUR2Reader";
 export { default as BCUR2Encoder } from "./BCUR2Encoder";
+export { default as DescriptorQRCodes } from "./DescriptorQRCodes";

--- a/apps/coordinator/src/components/TestSuiteRun/TestRun.jsx
+++ b/apps/coordinator/src/components/TestSuiteRun/TestRun.jsx
@@ -339,15 +339,19 @@ Derivation: ${test.params.derivation}
                               .interaction()
                               .parse("confirmed");
                             this.resolve(result);
+                            this.setState({ showBCURExport: false });
                           }}
                           style={{ marginRight: "10px" }}
                         >
-                          Confirm Address Matches Device
+                          Confirm Address Matches Wallet
                         </Button>
                         <Button
                           variant="outlined"
                           color="primary"
-                          onClick={this.reset}
+                          onClick={() => {
+                            this.reset();
+                            this.setState({ showBCURExport: false });
+                          }}
                         >
                           Cancel
                         </Button>

--- a/apps/coordinator/src/tests/bcur2.js
+++ b/apps/coordinator/src/tests/bcur2.js
@@ -2,5 +2,8 @@ import { BCUR2 } from "@caravan/wallets";
 
 import extendedPublicKeyTests from "./extendedPublicKeys";
 import { signingTests } from "./signing";
+import addressTests from "./addresses";
 
-export default extendedPublicKeyTests(BCUR2).concat(signingTests(BCUR2));
+export default extendedPublicKeyTests(BCUR2)
+  .concat(signingTests(BCUR2))
+  .concat(addressTests(BCUR2));

--- a/packages/caravan-wallets/src/bcur2/interactions.ts
+++ b/packages/caravan-wallets/src/bcur2/interactions.ts
@@ -715,6 +715,18 @@ export class BCUR2ConfirmMultisigAddress extends BCUR2Interaction {
   }
 
   /**
+   * Parses the confirmation response
+   * @param {string} data - Confirmation string (e.g., "confirmed")
+   * @returns {Object} The result with address and confirmation status
+   */
+  parse(data: string) {
+    if (data === "confirmed") {
+      this.confirmed = true;
+    }
+    return this.getResult();
+  }
+
+  /**
    * Checks if the address has been confirmed
    * @returns {boolean} True if address is confirmed
    */

--- a/packages/caravan-wallets/src/index.ts
+++ b/packages/caravan-wallets/src/index.ts
@@ -21,6 +21,7 @@ import {
   BCUR2ExportExtendedPublicKey,
   BCUR2EncodeTransaction,
   BCUR2SignMultisigTransaction,
+  BCUR2ConfirmMultisigAddress,
 } from "./bcur2/interactions";
 import {
   BITBOX,
@@ -624,6 +625,17 @@ export function ConfirmMultisigAddress({
         expected: multisig.address,
         bip32Path,
         policyHmac,
+      });
+    }
+    case BCUR2: {
+      const braidDetails: BraidDetails = JSON.parse(multisig.braidDetails);
+      const _walletConfig =
+        walletConfig || braidDetailsToWalletConfig(braidDetails);
+      return new BCUR2ConfirmMultisigAddress({
+        address: multisig.address,
+        bip32Path,
+        network,
+        walletConfig: _walletConfig,
       });
     }
     default:


### PR DESCRIPTION
Scan the address QR: 
<img width="631" height="553" alt="Screenshot 2025-10-05 at 3 01 46 PM" src="https://github.com/user-attachments/assets/2376fff5-3714-4708-a341-0467c8c4b775" />

Since its multisig, You'll have to load descriptor  and thus need to scan it's QR code then: 
<img width="506" height="356" alt="Screenshot 2025-10-05 at 3 02 39 PM" src="https://github.com/user-attachments/assets/4548304f-1705-41b3-9a78-285b067e5584" />

After that it will verify the address on ur hardware wallet: 
<img width="558" height="318" alt="Screenshot 2025-10-05 at 3 03 28 PM" src="https://github.com/user-attachments/assets/cdbfe61b-521e-4e71-b9fc-629e769665c2" />

If you see the green screen in ur hardware wallet, press "Address Matched" button on the test suite to make it pass the test. 
