### PR TITLE
feat: add Vercel configuration for redirects to bip370.org

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+    "redirects": [
+      {
+        "source": "/:path*",
+        "has": [
+          {
+            "type": "host",
+            "value": "bip370.caravanmultisig.com"
+          }
+        ],
+        "destination": "https://bip370.org/",
+        "permanent": true
+      }
+    ]
+  }


### PR DESCRIPTION
Add configuration to enable Vercel to redirect bip370.caravanmultisig.com to https://bip370.org/.  This will need to be merged before October 21st.