### PR TITLE
chore: update Vercel configuration to include additional redirect for…

### DIFF
--- a/apps/coordinator/vercel.json
+++ b/apps/coordinator/vercel.json
@@ -1,15 +1,27 @@
 {
-    "redirects": [
-      {
-        "source": "/:path*",
-        "has": [
-          {
-            "type": "host",
-            "value": "bip370.caravanmultisig.com"
-          }
-        ],
-        "destination": "https://bip370.org/",
-        "permanent": true
-      }
-    ]
-  }
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "redirects": [
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
+          "value": "bip370.caravanmultisig.com"
+        }
+      ],
+      "destination": "https://bip370.org/",
+      "permanent": true
+    },
+    {
+      "source": "/:path*",
+      "has": [
+        {
+          "type": "host",
+          "value": "bip370.caravanmultisig.com"
+        }
+      ],
+      "destination": "https://bip370.org/",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
This should fix the issue where visiting just bip370.caravanmultisig.com wasn't redirecting, while bip370.caravanmultisig.com/foo is working correctly.