### PR TITLE
Fix: Disable Git Hooks During Docs Deployment - 2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,6 +47,9 @@ jobs:
           # Save the generated docs to a temp location
           mv docs docs_temp
 
+          # Disable git hooks so Husky doesn't fail after we delete files
+          git config core.hooksPath /dev/null
+
           # Create and switch to an orphan docs branch
           git checkout --orphan docs
 
@@ -58,7 +61,7 @@ jobs:
 
           # Stage and commit
           git add .
-          git commit --no-verify -m "chore(docs): update typedocs [skip ci]" # To prevent precommit hook check
+          git commit -m "chore(docs): update typedocs [skip ci]" --no-verify
 
           # Force push to create/update the docs branch
           git push -f origin docs


### PR DESCRIPTION

## Fix: Disable Git Hooks During Docs Deployment

This PR addresses the second failure we hit in the docs publishing workflow.

Previously, we tried using:

```sh
git commit -m "chore(docs): update typedocs [skip ci]"
# and then
git commit --no-verify -m "chore(docs): update typedocs [skip ci]"
```

…but the workflow still failed because Husky’s Git hooks were being triggered **even after** we deleted the entire working directory on the orphan `docs` branch.

Actually the root cause was : 

* Running `npm ci` installs Husky and configures Git to use the `.husky` directory for hooks.
* When the workflow switches to the orphan `docs` branch, it runs `git rm -rf .`, which deletes the entire working directory **including `.husky/`**.
* Git still thinks hooks are enabled and tries to run `prepare-commit-msg`.
* The hook script points to `.husky/_/h`, which no longer exists → causing the CI to crash with
  `cannot open .husky/_/h: No such file`.

In short: **Git was trying to execute a hook script we just deleted.**

We now explicitly disable Git hooks during the docs publish step:

```sh
git config core.hooksPath /dev/null
```

This ensures no Husky hook runs during the orphan-branch commit, preventing the missing-file crash and allowing the docs branch to publish cleanly.

Hopefully this works :) 
