### PR TITLE
Fix : Docs publishing workflow to prevent Jekyll processing errors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,23 +44,35 @@ jobs:
             exit 1
           fi
 
-          # Save the generated docs to a temp location
-          mv docs docs_temp
-
           # Disable git hooks so Husky doesn't fail after we delete files
           git config core.hooksPath /dev/null
+
+          # Save the generated docs to a temporary location outside the working directory
+          # This protects them from being deleted in the next steps
+          mv docs /tmp/docs_temp
 
           # Create and switch to an orphan docs branch
           git checkout --orphan docs
 
-          # Clear existing contents but preserve git directory
+          # Remove all tracked files from git's index
+          # Note: This doesn't delete untracked files like node_modules
           git rm -rf . || true
 
-          # Copy the new docs in
-          cp -r docs_temp/* .
+          # Physically remove all files including untracked ones (node_modules, etc.)
+          # The -f forces deletion, -r is recursive, and we exclude .git to preserve the repo
+          find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+
+          # Copy only the generated documentation into the clean working directory
+          cp -r /tmp/docs_temp/* .
+
+          # Create .nojekyll file to tell GitHub Pages to skip Jekyll processing
+          # This is crucial because TypeDoc output is already complete static HTML
+          touch .nojekyll
 
           # Stage and commit
           git add .
+
+          # Commit with skip ci flag to prevent infinite workflow loops and also no verify for the not running any git hooks
           git commit -m "chore(docs): update typedocs [skip ci]" --no-verify
 
           # Force push to create/update the docs branch


### PR DESCRIPTION
**Problem**

The documentation publishing workflow was failing when GitHub Pages attempted to build the docs branch. Jekyll (GitHub's default static site generator) was encountering TypeScript ESLint documentation files in leftover `node_modules` directories and crashing with template syntax errors. 

The root cause involved two issues:
- `git rm` only removes tracked files, leaving untracked `node_modules` directories in the working tree
- GitHub Pages was attempting to process TypeDoc-generated HTML with Jekyll, which is unnecessary and caused parsing failures

**Solution**

This PR implements two key fixes:

First, we now create a `.nojekyll` file in the docs branch root. This special marker tells GitHub Pages to serve our files as static content without any Jekyll processing. Since TypeDoc already generates complete, production-ready HTML documentation, Jekyll processing is not needed and actively harmful.

Second, we physically clean the entire working directory (except `.git`) using `find` before copying documentation files. This ensures that only our generated documentation reaches the docs branch, with no leftover build artifacts or `node_modules` that could interfere with deployment , like it was before :) 
