### PR TITLE
feat(wallets): add human-readable Ledger error messages

### DIFF
--- a/.changeset/friendly-ledger-errors.md
+++ b/.changeset/friendly-ledger-errors.md
@@ -1,0 +1,17 @@
+---
+"@caravan/wallets": minor
+---
+
+Add human-readable Ledger error messages
+
+This change adds a comprehensive mapping of Ledger device error codes to user-friendly messages. When a Ledger operation fails, users will now see helpful messages like "User denied the request on the Ledger device" instead of cryptic codes like "0x6985" or "21781".
+
+New exports:
+- `LEDGER_ERROR_MESSAGES`: A map of error codes to human-readable messages
+- `translateLedgerError`: A function to translate Ledger errors into user-friendly messages
+
+Common error codes now have helpful translations:
+- 6985/21781: User denied the request
+- 6e00: Device locked or wrong app open
+- 6a82: Bitcoin app not found
+- Various transport-level errors (disconnected, busy, access denied)


### PR DESCRIPTION
## Summary
- Add `LEDGER_ERROR_MESSAGES` constant mapping Ledger error codes to user-friendly messages
- Add `translateLedgerError` function to translate cryptic error codes into helpful messages
- Update `withTransport` error handling to use the new translation function

When a Ledger operation fails, users now see helpful messages like "User denied the request on the Ledger device" instead of cryptic codes like `0x6985` or `21781`.

## Common error codes translated
| Code | Message |
|------|---------|
| 6985 / 21781 | User denied the request on the Ledger device |
| 6e00 | Device is locked or wrong app is open |
| 6a82 | Application not found - open the Bitcoin app |
| 6d00 | Operation not supported by the current app |
| disconnected | Ledger device disconnected |
| device is busy | Device busy - wait or reconnect |

## Test plan
- [x] All existing Ledger tests pass (78 tests)
- [x] New tests for `translateLedgerError` function added
- [x] Tests cover hex codes, decimal codes, known phrases, and unknown errors