### PR TITLE
Fix psbt dependency issue

### DIFF
--- a/.changeset/cuddly-mirrors-love.md
+++ b/.changeset/cuddly-mirrors-love.md
@@ -1,0 +1,5 @@
+---
+"@caravan/psbt": patch
+---
+
+Move @caravan/multisig to the proper dependency category in the psbt package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30741,6 +30741,7 @@
       "dependencies": {
         "@caravan/bip32": "*",
         "@caravan/bitcoin": "*",
+        "@caravan/multisig": "*",
         "@noble/curves": "^1.8.1",
         "bignumber.js": "^8.1.1",
         "bip174": "^2.1.1",
@@ -30752,7 +30753,6 @@
       "devDependencies": {
         "@caravan/build-plugins": "*",
         "@caravan/eslint-config": "*",
-        "@caravan/multisig": "*",
         "@caravan/typescript-config": "*",
         "eslint-plugin-prettier": "^5.1.3",
         "lodash": "^4.17.21",

--- a/packages/caravan-psbt/package.json
+++ b/packages/caravan-psbt/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@caravan/bip32": "*",
     "@caravan/bitcoin": "*",
+    "@caravan/multisig": "*",
     "bignumber.js": "^8.1.1",
     "bip174": "^2.1.1",
     "bitcoinjs-lib-v6": "npm:bitcoinjs-lib@^6.1.5",
@@ -57,7 +58,6 @@
   "devDependencies": {
     "@caravan/build-plugins": "*",
     "@caravan/eslint-config": "*",
-    "@caravan/multisig": "*",
     "@caravan/typescript-config": "*",
     "eslint-plugin-prettier": "^5.1.3",
     "lodash": "^4.17.21",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Dependency fix

**Summary**

[@caravan/psbt@2.0.6](https://github.com/caravan-bitcoin/caravan/pull/452) changed how the package bundled dependencies, explicitly excluding external packages. The `@caravan/multisig` package was listed in the `devDependencies` of the psbt package, but it was actually a runtime dependency. Because of this, it is not automatically installed by `npm i` as a subdependency when installing `@caravan/psbt`

This problem went unobserved while testing [@caravan/psbt@2.0.6](https://github.com/caravan-bitcoin/caravan/pull/452) because the Caravan coordinator app already had the `@caravan/multisig` package available to build with. When testing on external apps, I had used `npm link` which would also have included the psbt package `node_modules` again including the dependency.

This time I tested on an external app by installing the artifact created with `npm pack`.