### PR TITLE
Add e2e test for invalid PSBT upload

### DIFF
--- a/.changeset/invalid-psbt-e2e-test.md
+++ b/.changeset/invalid-psbt-e2e-test.md
@@ -1,0 +1,8 @@
+---
+"caravan-coordinator": none
+---
+
+Add an end-to-end test that validates error handling when importing an invalid PSBT file.
+The test asserts that an error is surfaced to the user and that the signing flow is blocked
+when PSBT parsing fails.
+

--- a/.changeset/invalid-psbt-e2e-test.md
+++ b/.changeset/invalid-psbt-e2e-test.md
@@ -1,8 +1,0 @@
----
-"caravan-coordinator": none
----
-
-Add an end-to-end test that validates error handling when importing an invalid PSBT file.
-The test asserts that an error is surfaced to the user and that the signing flow is blocked
-when PSBT parsing fails.
-

--- a/apps/coordinator/e2e/pages/SendTab.ts
+++ b/apps/coordinator/e2e/pages/SendTab.ts
@@ -92,6 +92,14 @@ export class SendTab {
     await btn.click();
   }
 
+  async importPsbtFile(psbtPath: string) {
+    await this.page.getByText("Import PSBT").scrollIntoViewIfNeeded();
+    await this.page.getByRole("combobox", { name: /import method/i }).click();
+    await this.page.getByRole("option", { name: /file upload/i }).click();
+    await this.page.locator('input[type="file"]').setInputFiles(psbtPath);
+    await this.page.getByRole("button", { name: /import psbt file/i }).click();
+  }
+
   async downloadUnsignedPsbt(savePath: string): Promise<string> {
     const btn = this.page.locator(
       'button[type=button]:has-text("Download Unsigned PSBT")',

--- a/apps/coordinator/e2e/tests/mutate/transaction-flow.spec.ts
+++ b/apps/coordinator/e2e/tests/mutate/transaction-flow.spec.ts
@@ -44,6 +44,21 @@ test.describe.serial("Transaction Creation and Signing", () => {
     await walletNav.switchToTab("Send");
   });
 
+  test("invalid PSBT upload: shows error and blocks signing", async ({
+    sendTab,
+    page,
+  }) => {
+    const invalidPsbtPath = path.join(uploadDir, "invalid.psbt");
+    fs.writeFileSync(invalidPsbtPath, "this-is-not-a-valid-psbt");
+
+    await sendTab.importPsbtFile(invalidPsbtPath);
+
+    await expect(page.getByRole("alert")).toBeVisible({ timeout: 10000 });
+    await expect(
+      page.getByRole("button", { name: /sign transaction/i }),
+    ).not.toBeVisible();
+  });
+
   test("auto coin selection: create, sign, broadcast", async ({
     sendTab,
     signTab,


### PR DESCRIPTION
Test / Quality improvement (E2E test)

Fixes #442

This PR adds an end-to-end test to validate Caravan’s behavior when an invalid PSBT file is uploaded.

The test ensures that:
- Uploading an invalid PSBT triggers a visible error alert
- The transaction signing flow is blocked for invalid PSBT inputs

This improves test coverage and prevents regressions related to PSBT validation.

- [x] I have tested my changes thoroughly.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally, and all tests pass.
- [x] I have written tests for all new changes/features.
- [x] I have followed the project's coding style and conventions.


- Added E2E test in:
  `apps/coordinator/e2e/tests/03-transaction_flow.spec.ts`
- Verified locally using `npm run test:e2e`

 Have you read the contributing guide?
Yes
