### PR TITLE
e2e: Add test for testing different address types

### DIFF
--- a/apps/coordinator/e2e/tests/mutate/address_types.spec.ts
+++ b/apps/coordinator/e2e/tests/mutate/address_types.spec.ts
@@ -1,0 +1,93 @@
+import fs from "fs";
+import path from "path";
+import { test, expect } from "../../fixtures/caravan.fixture";
+import { testStateManager } from "../../state/testState";
+import { clientConfig } from "../../services/bitcoinClient";
+
+const ADDRESS_TYPES = [
+  { 
+    type: "P2WSH", 
+    label: "Native SegWit (P2WSH)", 
+    regex: /^bcrt1q[0-9a-z]{58}$/  
+  },
+  { 
+    type: "P2SH-P2WSH", 
+    label: "Nested SegWit (P2SH-P2WSH)", 
+    regex: /^2[1-9A-HJ-NP-Za-km-z]{30,40}$/ 
+  },
+  { 
+    type: "P2TR", 
+    label: "Taproot (P2TR)", 
+    regex: /^bcrt1p.{50,}$/, 
+    skip: true 
+  }
+];
+
+test.describe("Wallet Address Types", () => {
+  test.beforeEach(async ({ page }) => {
+    // Ensure we start with a slight delay to allow any previous cleanup
+    await page.waitForTimeout(1000);
+  });
+
+  for (const { type, label, regex, skip } of ADDRESS_TYPES) {
+    const testFn = skip ? test.skip : test;
+    testFn(`should handle ${label} wallet correctly`, async ({ page, walletImport, receiveTab, btcClient }) => {
+      try {
+        // 1. Get Base Config
+        const downloadedWalletFile = testStateManager.getDownloadedWalletFile();
+        if (!fs.existsSync(downloadedWalletFile)) {
+            throw new Error(`Wallet file not found at ${downloadedWalletFile}. Please run previous tests.`);
+        }
+        
+        const walletConfig = JSON.parse(fs.readFileSync(downloadedWalletFile, "utf-8"));
+        
+        // 2. Modify Config for Address Type
+        walletConfig.addressType = type;
+        if (walletConfig.client) {
+            walletConfig.client.url = "http://localhost:8080"; 
+        } else {
+            walletConfig.client = { url: "http://localhost:8080" };
+        }
+        walletConfig.network = "regtest";
+        walletConfig.name = `Wallet ${type}`;
+        
+        // Save as temporary file
+        const tempConfigPath = path.join(
+            path.dirname(downloadedWalletFile), 
+            `wallet_config_${type}.json`
+        );
+        fs.writeFileSync(tempConfigPath, JSON.stringify(walletConfig, null, 2));
+
+        // 3. Import into Caravan
+        await walletImport.importWalletAndPrepare(tempConfigPath, clientConfig.password);
+
+        // 4. Verify Address Format (Receive Tab)
+        await page.locator("button[role=tab][type=button]:has-text('Receive')").click();
+        const address = await receiveTab.getCurrentAddress();
+        console.log(`Generated ${type} Address: ${address}`);
+        
+        expect(address).toMatch(regex);
+
+        // 5. Test Basic Transaction (Send data to this address)
+        const senderWallet = testStateManager.getState().test_wallet_names[0];
+        
+        const initialSuffix = await receiveTab.getCurrentPathSuffix();
+
+        // Send 1 BTC
+        await btcClient?.sendToAddress(senderWallet, address, 1);
+
+        // Wait for the UI to reflect new tx / increment path
+        await expect.poll(async () => {
+            return await receiveTab.getCurrentPathSuffix();
+        }, {
+            message: "Address path should increment after receiving funds",
+            timeout: 30000,
+            intervals: [1000]
+        }).not.toBe(initialSuffix); 
+
+      } catch (error) {
+        throw new Error(`Failed testing ${type}: ${error}`);
+      }
+    });
+  }
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Test improvement / E2E test coverage

**Issue Number:**

Fixes subtask of #442

**If relevant, did you update the documentation?**

- Not applicable (test-only change)

**Summary**
This PR adds, parameterized end-to-end tests to validate different wallet address types in the Caravan coordinator.

Previously, E2E tests mainly covered the default address behavior. This change ensures comprehensive coverage for:

P2WSH (Native SegWit): Verifies correct address generation (bcrt1q...) and fund reception.
P2SH-P2WSH (Nested SegWit): Verifies correct address generation (2...) and fund reception.
P2TR (Taproot): Test scaffold included but **currently skipped.**
For each active type, the test validates:

1. Importing a wallet configuration specific to that address type.
2. Verifying the generated receive address matches the expected regex format.
3. Confirming the wallet can receive a transaction (verified by the address path index incrementing locally).

**Does this PR introduce a breaking change?**

-No

 **Checklist**
- [x] I have tested my changes thoroughly.
- [x] I have added or updated tests to cover my changes (if applicable).
- [ ] I have verified that test coverage meets or exceeds 95% (if applicable).
- [x] I have run the test suite locally, and all tests pass.
- [x] I have written tests for all new changes/features
- [x] I have followed the project's coding style and conventions.
- [ ] I have created a changeset to document my changes (`` npm run changeset ``)




**Other information**

P2TR (Taproot) skipped: The P2TR test case is explicitly marked as `skip: true`. Investigation into 
`caravan-bitcoin/src/types/addresses.ts`revealed that while P2TR is defined as a valid 
MultisigAddressType, it is currently commented as "not able to be used anywhere yet". The test is preserved to enable immediate verification once support is fully implemented in the underlying package.

All coordinator E2E tests (P2WSH and P2SH-P2WSH) pass locally using the Docker-based setup.


**Have you read the [contributing guide](https://github.com/caravan-bitcoin/caravan/blob/main/apps/coordinator/CONTRIBUTING.md)?**

Yes
