### PR TITLE
e2e: block preview transaction when fee rate is invalid

### DIFF
--- a/apps/coordinator/e2e/tests/03-transaction_flow.spec.ts
+++ b/apps/coordinator/e2e/tests/03-transaction_flow.spec.ts
@@ -353,7 +353,18 @@ test.describe("Transaction Creation and Signing", () => {
   });
 
   test("should not allow preview transaction when fee rate is invalid", async ({ page }) => {
-  // TODO
+  const receiverAddress = testStateManager.getReceiver().address;
+
+    // Destination
+  await page.locator('input[name="destination"]').fill(receiverAddress);
+
+    // Amount
+  await page.locator('input[name="amount"]').fill("1");
+
+  await page.locator('input[name="fee_rate"]').fill("-1");
+  const previewButton = page.locator('button:has-text("Preview Transaction")');
+
+  await expect(previewButton).toBeDisabled();
 });
 
 });

--- a/apps/coordinator/e2e/tests/03-transaction_flow.spec.ts
+++ b/apps/coordinator/e2e/tests/03-transaction_flow.spec.ts
@@ -351,4 +351,9 @@ test.describe("Transaction Creation and Signing", () => {
       throw new Error(error);
     }
   });
+
+  test("should not allow preview transaction when fee rate is invalid", async ({ page }) => {
+  // TODO
+});
+
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Test improvement / E2E test coverage

**Issue Number:**

Fixes subtask of #442

**Snapshots/Videos:**

Not applicable (test-only change)

**If relevant, did you update the documentation?**

Not applicable

**Summary**

This PR adds an end-to-end test to ensure that the Preview Transaction step
is not accessible when the fee rate input is invalid.

The test asserts that the system does not expose a forbidden transition
in the Send flow, ensuring users cannot proceed to transaction preview
when required preconditions are not met.

**Does this PR introduce a breaking change?**

No

## Checklist
- [x] I have tested my changes thoroughly.
- [x] I have added or updated tests to cover my changes (if applicable).
- [ ] I have verified that test coverage meets or exceeds 95% (if applicable).
- [x] I have run the test suite locally, and all tests pass.
- [x] I have written tests for all new changes/features
- [x] I have followed the project's coding style and conventions.
- [ ] I have created a changeset to document my changes (`npm run changeset`)

**Other information**

This test validates UI-level state transitions and remains valid even if
backend fee validation logic is refactored, as long as invalid fees must
not allow progression to the Preview step.

**Have you read the contributing guide?**

Yes