### PR TITLE
e2e: Testing different public API providers

### DIFF
--- a/apps/coordinator/e2e/tests/04-client_connections.spec.ts
+++ b/apps/coordinator/e2e/tests/04-client_connections.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Public API Provider Client Connections", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/#/wallet");
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("should show public provider radio buttons enabled on mainnet", async ({
+    page,
+  }) => {
+    const mempoolRadio = page.getByRole("radio", { name: /Mempool\.space/i });
+    const blockstreamRadio = page.getByRole("radio", {
+      name: /Blockstream\.info/i,
+    });
+    const privateRadio = page.getByRole("radio", { name: /Private/i });
+
+    await expect(mempoolRadio).toBeEnabled();
+    await expect(blockstreamRadio).toBeEnabled();
+    await expect(privateRadio).toBeEnabled();
+
+    // Mempool.space is the default provider
+    await expect(mempoolRadio).toBeChecked();
+  });
+
+  test("should select Mempool provider and reflect selection in UI", async ({
+    page,
+  }) => {
+    // First switch away from the default to ensure clicking Mempool actually works
+    const blockstreamRadio = page.getByRole("radio", {
+      name: /Blockstream\.info/i,
+    });
+    await blockstreamRadio.click();
+    await expect(blockstreamRadio).toBeChecked();
+
+    // Now select Mempool
+    const mempoolRadio = page.getByRole("radio", { name: /Mempool\.space/i });
+    await mempoolRadio.click();
+
+    await expect(mempoolRadio).toBeChecked();
+    await expect(blockstreamRadio).not.toBeChecked();
+
+    // Private client settings should NOT be visible
+    await expect(page.locator("#bitcoind-username")).not.toBeVisible();
+  });
+
+  test("should select Blockstream provider and reflect selection in UI", async ({
+    page,
+  }) => {
+    const blockstreamRadio = page.getByRole("radio", {
+      name: /Blockstream\.info/i,
+    });
+    await blockstreamRadio.click();
+
+    await expect(blockstreamRadio).toBeChecked();
+
+    // Mempool should no longer be checked
+    const mempoolRadio = page.getByRole("radio", { name: /Mempool\.space/i });
+    await expect(mempoolRadio).not.toBeChecked();
+
+    // Private client settings should NOT be visible
+    await expect(page.locator("#bitcoind-username")).not.toBeVisible();
+  });
+
+  test("should switch between Mempool, Blockstream, and Private providers", async ({
+    page,
+  }) => {
+    const mempoolRadio = page.getByRole("radio", { name: /Mempool\.space/i });
+    const blockstreamRadio = page.getByRole("radio", {
+      name: /Blockstream\.info/i,
+    });
+    const privateRadio = page.getByRole("radio", { name: /Private/i });
+
+    // Mempool should be the default
+    await expect(mempoolRadio).toBeChecked();
+
+    // Switch to Blockstream
+    await blockstreamRadio.click();
+    await expect(blockstreamRadio).toBeChecked();
+    await expect(mempoolRadio).not.toBeChecked();
+    await expect(page.locator("#bitcoind-username")).not.toBeVisible();
+
+    // Switch to Private — settings panel should appear
+    await privateRadio.click();
+    await expect(privateRadio).toBeChecked();
+    await expect(blockstreamRadio).not.toBeChecked();
+    await expect(page.locator("#bitcoind-username")).toBeVisible();
+
+    // Switch back to Mempool — settings panel should disappear
+    await mempoolRadio.click();
+    await expect(mempoolRadio).toBeChecked();
+    await expect(privateRadio).not.toBeChecked();
+    await expect(page.locator("#bitcoind-username")).not.toBeVisible();
+  });
+
+});
+
+test.describe("Public API Response Validation", () => {
+  test("should fetch valid fee estimates from Mempool.space API", async ({
+    request,
+  }) => {
+    await expect(async () => {
+      // Get fee data
+      const response = await request.get(
+        "https://unchained.mempool.space/api/v1/fees/recommended",
+      );
+      expect(response.ok()).toBeTruthy();
+
+      const data = await response.json();
+
+      expect(data).toHaveProperty("fastestFee");
+      expect(data).toHaveProperty("halfHourFee");
+      expect(data).toHaveProperty("hourFee");
+      expect(data).toHaveProperty("economyFee");
+      expect(typeof data.fastestFee).toBe("number");
+      expect(typeof data.halfHourFee).toBe("number");
+      expect(typeof data.hourFee).toBe("number");
+      expect(typeof data.economyFee).toBe("number");
+    }).toPass({ timeout: 30_000, intervals: [2_000, 5_000, 10_000] });
+  });
+
+  test("should fetch valid fee estimates from Blockstream.info API", async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const response = await request.get(
+        "https://blockstream.info/api/fee-estimates",
+      );
+      expect(response.ok()).toBeTruthy();
+
+      const data = await response.json();
+      expect(typeof data).toBe("object");
+      const keys = Object.keys(data);
+      expect(keys.length).toBeGreaterThan(0);
+
+      for (const key of keys) {
+        expect(typeof data[key]).toBe("number");
+        expect(data[key]).toBeGreaterThan(0);
+      }
+    }).toPass({ timeout: 30_000, intervals: [2_000, 5_000, 10_000] });
+  });
+
+  test("should fetch valid address data from Mempool.space API", async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const address = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
+      const response = await request.get(
+        `https://unchained.mempool.space/api/address/${address}`,
+      );
+      expect(response.ok()).toBeTruthy();
+
+      const data = await response.json();
+
+      expect(data).toHaveProperty("chain_stats");
+      expect(data.chain_stats).toHaveProperty("funded_txo_count");
+      expect(data.chain_stats).toHaveProperty("funded_txo_sum");
+      expect(data.chain_stats).toHaveProperty("spent_txo_count");
+      expect(data.chain_stats).toHaveProperty("spent_txo_sum");
+      expect(data.chain_stats).toHaveProperty("tx_count");
+      expect(data).toHaveProperty("mempool_stats");
+      expect(typeof data.chain_stats.funded_txo_count).toBe("number");
+      expect(typeof data.chain_stats.tx_count).toBe("number");
+
+      // address should be used
+      expect(data.chain_stats.funded_txo_count).toBeGreaterThan(0);
+    }).toPass({ timeout: 30_000, intervals: [2_000, 5_000, 10_000] });
+  });
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Test improvement / E2E test coverage
Issue Number:
 #442 

**If relevant, did you update the documentation?**

Not applicable (test-only change)

**Summary**

This PR adds end-to-end tests to cover public API provider selection and response validation in the Caravan coordinator.

Previously, selecting and switching between public Bitcoin client providers (Mempool.space, Blockstream.info) was not covered by E2E tests, and live API response shapes were only validated against mocked data in unit tests. This change ensures that:

- Public provider radio buttons are enabled and Mempool.space is the default on mainnet
- Selecting Mempool or Blockstream correctly updates the UI and hides private client settings
- Switching between Mempool, Blockstream, and Private providers behaves correctly across transitions
- Live fee estimate responses from Mempool.space and Blockstream.info match the expected shapes that BlockchainClient depends on
- Live address data from Mempool.space returns the chain_stats/mempool_stats structure used by getAddressStatus

Does this PR introduce a breaking change?

No

## Checklist
- [x] I have tested my changes thoroughly.
- [x] I have added or updated tests to cover my changes (if applicable).
- [ ] I have verified that test coverage meets or exceeds 95% (if applicable).
- [x] I have run the test suite locally, and all tests pass.
- [x] I have written tests for all new changes/features
- [x] I have followed the project's coding style and conventions.
- [ ] I have created a changeset to document my changes (`` npm run changeset ``)

**Other information**

nothing much

**Have you read the [contributing guide](https://github.com/caravan-bitcoin/caravan/blob/main/apps/coordinator/CONTRIBUTING.md)?**

Yes

**For information on creating and using changesets, please refer to our [documentation on changesets](https://github.com/caravan-bitcoin/caravan?tab=readme-ov-file#changesets)**.
