### PR TITLE
chore(e2e): swap bitcoin-core for @caravan/clients callBitcoind

### DIFF
--- a/.changeset/late-tips-change.md
+++ b/.changeset/late-tips-change.md
@@ -1,0 +1,7 @@
+---
+"@caravan/clients": patch
+---
+
+Export `callBitcoind` from the package index. Previously only reachable
+via the internal `./bitcoind` subpath, this is a generic JSON-RPC helper
+useful for any consumer talking directly to bitcoind.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,7 +71,6 @@ jobs:
             max_attempts: 3
             timeout_minutes: 15
             command: |
-              cd apps/coordinator
               npm run test:e2e
             on_retry_command: |
               echo "Cleaning up before retry..."

--- a/apps/coordinator/e2e/services/bitcoinServices.ts
+++ b/apps/coordinator/e2e/services/bitcoinServices.ts
@@ -1,4 +1,4 @@
-import BitcoinCore from "bitcoin-core";
+import { callBitcoind } from "@caravan/clients";
 import {
   SingleSigAddressType,
   descStructure,
@@ -7,38 +7,33 @@ import {
 } from "../state/types";
 
 export class BitcoinCoreService {
-  private clientConfig: rpcConfig;
-  private client: BitcoinCore;
-  private walletClient: Map<string, BitcoinCore> = new Map();
+  private readonly baseUrl: string;
+  private readonly auth: { username: string; password: string };
 
   constructor(clientConfig: rpcConfig) {
-    this.clientConfig = {
+    this.baseUrl = clientConfig.host;
+    this.auth = {
       username: clientConfig.username,
       password: clientConfig.password,
-      port: clientConfig.port,
-      host: clientConfig.host,
     };
-
-    this.client = new BitcoinCore(this.clientConfig);
   }
 
-  private getWalletClient(walletName: string) {
-    try {
-      if (!this.walletClient.has(walletName)) {
-        const walletClient = new BitcoinCore({
-          ...this.clientConfig,
-          wallet: walletName,
-        });
-        this.walletClient.set(walletName, walletClient);
+  private walletUrl(walletName: string): string {
+    return `${this.baseUrl}/wallet/${walletName}`;
+  }
 
-        return this.walletClient.get(walletName);
-      }
-      return this.walletClient.get(walletName);
-    } catch (error) {
+  private async rpc<T>(
+    url: string,
+    method: string,
+    params: unknown[] = [],
+  ): Promise<T> {
+    const response = await callBitcoind<T>(url, this.auth, method, params);
+    if (response.error) {
       throw new Error(
-        `Failed to get wallet client for '${walletName}': ${error}`,
+        `bitcoind RPC '${method}' failed: ${response.error.code} ${response.error.message}`,
       );
     }
+    return response.result;
   }
 
   async waitForBitcoinCore() {
@@ -47,9 +42,7 @@ export class BitcoinCoreService {
 
     for (let i = 1; i <= maxRetries; i++) {
       try {
-        const res = await this.client.command("getblockchaininfo");
-
-        return res;
+        return await this.rpc<unknown>(this.baseUrl, "getblockchaininfo");
       } catch (error) {
         console.log(`Attempt: ${i}/${maxRetries} & error: ${error} `);
         if (i == maxRetries) {
@@ -57,7 +50,6 @@ export class BitcoinCoreService {
             `Failed to connect to Bitcoin Core RPC after ${maxRetries} attempts: ${error}`,
           );
         }
-        //waiting for retry
         await new Promise((resolve) => setTimeout(resolve, delay));
       }
     }
@@ -65,8 +57,7 @@ export class BitcoinCoreService {
 
   async getBlockchainInfo() {
     try {
-      const blockchainInfo = await this.client.command("getblockchaininfo");
-      return blockchainInfo;
+      return await this.rpc<unknown>(this.baseUrl, "getblockchaininfo");
     } catch (error) {
       throw new Error(`Failed to fetch blockchain info: ${error}`);
     }
@@ -74,18 +65,16 @@ export class BitcoinCoreService {
 
   async createWallet(walletConfig: walletConfig) {
     try {
-      const wallet = await this.client.command(
-        "createwallet",
+      return await this.rpc<unknown>(this.baseUrl, "createwallet", [
         walletConfig.wallet_name,
         walletConfig.disable_private_keys,
         walletConfig.blank,
         walletConfig.passphrase,
         walletConfig.avoid_reuse,
-        walletConfig.descriptors || true,
-        walletConfig.load_on_startup || true,
+        walletConfig.descriptors ?? true,
+        walletConfig.load_on_startup ?? true,
         walletConfig.external_signer,
-      );
-      return wallet;
+      ]);
     } catch (error) {
       throw new Error(
         `Failed to create wallet '${walletConfig.wallet_name}': ${error}`,
@@ -95,8 +84,7 @@ export class BitcoinCoreService {
 
   async loadWallets(walletName: string) {
     try {
-      const loadWallet = this.client.command("loadwallet", walletName);
-      return loadWallet;
+      return await this.rpc<unknown>(this.baseUrl, "loadwallet", [walletName]);
     } catch (error) {
       throw new Error(`Failed to load wallet '${walletName}': ${error}`);
     }
@@ -104,11 +92,9 @@ export class BitcoinCoreService {
 
   async unloadWallet(walletName: string) {
     try {
-      const unloadWallet = await this.client.command(
-        "unloadwallet",
+      return await this.rpc<unknown>(this.baseUrl, "unloadwallet", [
         walletName,
-      );
-      return unloadWallet;
+      ]);
     } catch (error) {
       throw new Error(`Failed to unload wallet '${walletName}': ${error}`);
     }
@@ -117,7 +103,6 @@ export class BitcoinCoreService {
   async walletExists(walletName: string): Promise<boolean> {
     try {
       const wallets = await this.listWallets();
-
       if (wallets && Array.isArray(wallets) && wallets.includes(walletName)) {
         return true;
       }
@@ -131,8 +116,7 @@ export class BitcoinCoreService {
 
   async listWallets() {
     try {
-      const allWallets = await this.client.command("listwallets");
-      return allWallets;
+      return await this.rpc<string[]>(this.baseUrl, "listwallets");
     } catch (error) {
       throw new Error(`Failed to list wallets: ${error}`);
     }
@@ -140,10 +124,10 @@ export class BitcoinCoreService {
 
   async listDescriptors(walletName: string) {
     try {
-      const walletClient = this.getWalletClient(walletName);
-
-      const descriptors = await walletClient?.command("listdescriptors");
-      return descriptors;
+      return await this.rpc<unknown>(
+        this.walletUrl(walletName),
+        "listdescriptors",
+      );
     } catch (error) {
       throw new Error(
         `Failed to list descriptors for wallet '${walletName}': ${error}`,
@@ -155,8 +139,9 @@ export class BitcoinCoreService {
     walletName: string,
   ): Promise<Record<SingleSigAddressType, descStructure>> {
     try {
-      const walletClient = this.getWalletClient(walletName);
-      const allDesc = await walletClient?.command("listdescriptors");
+      const allDesc = await this.rpc<{
+        descriptors: { desc: string }[];
+      }>(this.walletUrl(walletName), "listdescriptors");
 
       const standardDescRegex = /^\w+\(\[(.+?)\/(.+?)\](.+?)\/(.+?)\)\#(.+)$/;
       const shWpkhDescRegex =
@@ -212,12 +197,10 @@ export class BitcoinCoreService {
       );
     }
   }
+
   async checkBalance(walletName: string) {
     try {
-      const walletClient = this.getWalletClient(walletName);
-
-      const balance = await walletClient?.command("getbalance");
-      return balance;
+      return await this.rpc<number>(this.walletUrl(walletName), "getbalance");
     } catch (error) {
       throw new Error(
         `Failed to check balance for wallet '${walletName}': ${error}`,
@@ -227,10 +210,10 @@ export class BitcoinCoreService {
 
   async getNewAddress(walletName: string) {
     try {
-      const client = this.getWalletClient(walletName);
-
-      const address = await client?.command("getnewaddress");
-      return address;
+      return await this.rpc<string>(
+        this.walletUrl(walletName),
+        "getnewaddress",
+      );
     } catch (error) {
       throw new Error(
         `Failed to get new address from wallet '${walletName}': ${error}`,
@@ -240,10 +223,10 @@ export class BitcoinCoreService {
 
   async fundAddress(address: string, walletName: string, blocks?: number) {
     try {
-      let blockHashes = await this.client?.command(
+      const blockHashes = await this.rpc<string[]>(
+        this.baseUrl,
         "generatetoaddress",
-        blocks ?? 101,
-        address,
+        [blocks ?? 101, address],
       );
 
       const balance = await this.checkAddressBalance(address, walletName);
@@ -260,12 +243,11 @@ export class BitcoinCoreService {
 
   async checkAddressBalance(address: string, walletName: string) {
     try {
-      const walletClient = this.getWalletClient(walletName);
-      const balance = await walletClient?.command(
+      return await this.rpc<number>(
+        this.walletUrl(walletName),
         "getreceivedbyaddress",
-        address,
+        [address],
       );
-      return balance;
     } catch (error) {
       throw new Error(
         `Failed to check balance for address '${address}' in wallet '${walletName}': ${error}`,
@@ -275,15 +257,11 @@ export class BitcoinCoreService {
 
   async sendToAddress(walletName: string, toAddress: string, amount: number) {
     try {
-      const walletClient = this.getWalletClient(walletName);
-
-      let txid = await walletClient?.command(
+      return await this.rpc<string>(
+        this.walletUrl(walletName),
         "sendtoaddress",
-        toAddress,
-        amount,
+        [toAddress, amount],
       );
-
-      return txid;
     } catch (error) {
       throw new Error(
         `Failed to send ${amount} BTC from wallet '${walletName}' to address '${toAddress}': ${error}`,
@@ -301,7 +279,6 @@ export class BitcoinCoreService {
    * @param bip32derivs - whether to include the BIP32 derivation info (def: true)
    * @returns Object containing the signed PSBT and completion status
    */
-
   async signPsbt(
     walletName: string,
     psbtBase64: string,
@@ -310,14 +287,10 @@ export class BitcoinCoreService {
     bip32derivs: boolean = true,
   ): Promise<{ psbt: string; complete: boolean }> {
     try {
-      const walletClient = this.getWalletClient(walletName);
-
-      const result = await walletClient?.command(
+      const result = await this.rpc<{ psbt: string; complete: boolean }>(
+        this.walletUrl(walletName),
         "walletprocesspsbt",
-        psbtBase64,
-        signInputs,
-        sighashtype,
-        bip32derivs,
+        [psbtBase64, signInputs, sighashtype, bip32derivs],
       );
 
       return {
@@ -337,7 +310,6 @@ export class BitcoinCoreService {
    * @param psbtBase64 - Base64 encoded signed PSBT
    * @returns Array of signature objects with hex signatures and public keys
    */
-
   async extractSignaturesFromPsbt(psbtBase64: string): Promise<
     {
       signatures: string[];
@@ -346,8 +318,16 @@ export class BitcoinCoreService {
     }[]
   > {
     try {
-      const decodedPbst = await this.client.command("decodepsbt", psbtBase64);
-      const extractedSignatures: any = [];
+      const decodedPbst = await this.rpc<{
+        inputs: {
+          partial_signatures?: Record<string, string>;
+        }[];
+      }>(this.baseUrl, "decodepsbt", [psbtBase64]);
+      const extractedSignatures: {
+        signatures: string[];
+        publicKeys: string[];
+        inputIndex: number;
+      }[] = [];
 
       // Iterate through each input to extract signatures
       for (
@@ -362,12 +342,11 @@ export class BitcoinCoreService {
           const signatures: string[] = [];
           const publicKeys: string[] = [];
 
-          // Extract each signature and its corresponding public key
           for (const [pubkey, signature] of Object.entries(
             input.partial_signatures,
           )) {
             publicKeys.push(pubkey);
-            signatures.push(signature as string);
+            signatures.push(signature);
           }
 
           if (signatures.length > 0) {

--- a/apps/coordinator/package.json
+++ b/apps/coordinator/package.json
@@ -115,7 +115,6 @@
     "bignumber.js": "^9.0.0",
     "bip32": "^2.0.4",
     "bitcoin-address-validation": "^1.0.2",
-    "bitcoin-core": "^5.0.0",
     "bitcoinjs-lib": "^5.1.7",
     "bowser": "^2.6.1",
     "buffer": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
         "bignumber.js": "^9.0.0",
         "bip32": "^2.0.4",
         "bitcoin-address-validation": "^1.0.2",
-        "bitcoin-core": "^5.0.0",
         "bitcoinjs-lib": "^5.1.7",
         "bowser": "^2.6.1",
         "buffer": "^6.0.3",
@@ -9781,21 +9780,6 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
-    "node_modules/@uphold/request-logger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@uphold/request-logger/-/request-logger-2.0.0.tgz",
-      "integrity": "sha512-UvGS+v87C7VTtQDcFHDLfvfl1zaZaLSwSmAnV35Ne7CzAVvotmZqt9lAIoNpMpaoRpdjVIcnUDwPSeIeA//EoQ==",
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "request": ">=2.27.0"
-      }
-    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
@@ -10505,6 +10489,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -10732,15 +10717,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
     "node_modules/asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -10777,15 +10753,6 @@
         "object-is": "^1.1.5",
         "object.assign": "^4.1.4",
         "util": "^0.12.5"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/assert/node_modules/util": {
@@ -10875,21 +10842,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "license": "MIT"
     },
     "node_modules/axe-core": {
       "version": "4.7.0",
@@ -11194,7 +11146,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/base-x": {
       "version": "3.0.11",
@@ -11261,21 +11213,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
-    "node_modules/bcrypt-pbkdf/node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "license": "Unlicense"
     },
     "node_modules/bech32": {
       "version": "1.1.4",
@@ -11393,33 +11330,6 @@
         "base-x": "^3.0.6",
         "bech32": "^1.1.3",
         "sha.js": "^2.4.11"
-      }
-    },
-    "node_modules/bitcoin-core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bitcoin-core/-/bitcoin-core-5.0.0.tgz",
-      "integrity": "sha512-XqHsD5LjtshN8yWzRrq2kof57e1eXCGDx3i5+sFKBRi9MktSlXOR4SRLyXLkfzfBmPEs5q/76RotQJuaWg75DQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@uphold/request-logger": "^2.0.0",
-        "debugnyan": "^1.0.0",
-        "json-bigint": "^1.0.0",
-        "lodash": "^4.0.0",
-        "request": "^2.53.0",
-        "semver": "^5.1.0",
-        "standard-error": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=7"
-      }
-    },
-    "node_modules/bitcoin-core/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/bitcoin-ops": {
@@ -11858,24 +11768,6 @@
         "esbuild": ">=0.18"
       }
     },
-    "node_modules/bunyan": {
-      "version": "1.8.15",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
-      "integrity": "sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==",
-      "engines": [
-        "node >=0.10.0"
-      ],
-      "license": "MIT",
-      "bin": {
-        "bunyan": "bin/bunyan"
-      },
-      "optionalDependencies": {
-        "dtrace-provider": "~0.8",
-        "moment": "^2.19.3",
-        "mv": "~2",
-        "safe-json-stringify": "~1"
-      }
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -11997,12 +11889,6 @@
     "node_modules/caravan-coordinator": {
       "resolved": "apps/coordinator",
       "link": true
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
     },
     "node_modules/cashaddrjs": {
       "version": "0.4.4",
@@ -12374,7 +12260,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/confbox": {
       "version": "0.2.2",
@@ -12776,18 +12662,6 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
     },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -12891,34 +12765,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/debugnyan": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/debugnyan/-/debugnyan-1.0.0.tgz",
-      "integrity": "sha512-dTvKxcLZCammDLFYi31NRVr5g6vjJ33uf1wcdbIPPxPxxnJ9/xj00Mh/YQkhFMw/VGavaG5KpjSC+4o9r/JjRg==",
-      "license": "MIT",
-      "dependencies": {
-        "bunyan": "^1.8.1",
-        "debug": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/debugnyan/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/debugnyan/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/decimal.js": {
       "version": "10.6.0",
@@ -13162,20 +13008,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/dtrace-provider": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
-      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
-      "hasInstallScript": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "nan": "^2.14.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -13194,22 +13026,6 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "node_modules/ecc-jsbn/node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -14697,31 +14513,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
     "node_modules/extendable-error": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
       "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
       "dev": true
     },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -15016,15 +14818,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -15230,15 +15023,6 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
       }
     },
     "node_modules/gh-pages": {
@@ -15451,29 +15235,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -15684,21 +15445,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
-    },
     "node_modules/https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
@@ -15881,7 +15627,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -16361,12 +16107,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT"
-    },
     "node_modules/is-weakmap": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
@@ -16441,12 +16181,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -18775,15 +18509,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -18795,27 +18520,17 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -18862,21 +18577,6 @@
       "integrity": "sha512-ZRfiI5P7leJuWmvC0jGVXu227m68C2Jfz1dkDckshmDYDeVFCGxwIBYdCUXJ8Eb2CyFQC2ok82fEWO+xRDovDQ==",
       "peerDependencies": {
         "jspdf": "^2.0.0"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/jss": {
@@ -19988,7 +19688,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "devOptional": true,
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -20080,90 +19780,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/mv": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-      "integrity": "sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mkdirp": "~0.5.1",
-        "ncp": "~2.0.0",
-        "rimraf": "~2.4.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/mv/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/mv/node_modules/glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/mv/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/mv/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/mv/node_modules/rimraf": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-      "integrity": "sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "glob": "^6.0.1"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -20203,16 +19819,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "node_modules/ncp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "ncp": "bin/ncp"
-      }
     },
     "node_modules/node-addon-api": {
       "version": "3.2.1",
@@ -20528,15 +20134,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -20675,7 +20272,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -20924,7 +20521,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21027,7 +20624,8 @@
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -21437,11 +21035,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
@@ -22182,74 +21775,6 @@
       "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
       "license": "MIT"
     },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request/node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
-      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/request/node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -22584,13 +22109,6 @@
         }
       ]
     },
-    "node_modules/safe-json-stringify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
-      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/safe-regex-test": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.2.tgz",
@@ -22611,7 +22129,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "node_modules/sass": {
       "version": "1.70.0",
@@ -22992,43 +22511,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sshpk/node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "license": "MIT"
-    },
-    "node_modules/sshpk/node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "license": "Unlicense"
-    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -23066,11 +22548,6 @@
       "engines": {
         "node": ">=0.1.14"
       }
-    },
-    "node_modules/standard-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/standard-error/-/standard-error-1.1.0.tgz",
-      "integrity": "sha512-4v7qzU7oLJfMI5EltUSHCaaOd65J6S4BqKRWgzMi4EYaE5fvNabPxmAPGdxpGXqrcWjhDGI/H09CIdEuUOUeXg=="
     },
     "node_modules/std-env": {
       "version": "3.9.0",
@@ -24259,18 +23736,6 @@
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
       "dev": true
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/turbo": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.0.3.tgz",
@@ -24792,6 +24257,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -24882,15 +24348,6 @@
         "base64-arraybuffer": "^1.0.2"
       }
     },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -24938,26 +24395,6 @@
       "dependencies": {
         "safe-buffer": "^5.1.1"
       }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/verror/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.4.2",
@@ -25680,7 +25117,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",

--- a/packages/caravan-clients/src/index.ts
+++ b/packages/caravan-clients/src/index.ts
@@ -1,4 +1,5 @@
 export { bitcoindImportDescriptors } from "./wallet";
+export { callBitcoind } from "./bitcoind";
 export { BlockchainClient, ClientType, PublicBitcoinProvider } from "./client";
 export type {
   UTXO,


### PR DESCRIPTION
## Summary

The Playwright e2e harness was the only consumer of `bitcoin-core` in the repo. `bitcoin-core@5.x` pins to the deprecated `request@2.x` and pulls a chain of unfixable advisories (critical `form-data`, critical `request`, plus `qs`, `tough-cookie`, `@uphold/request-logger`). None of it reached shipped coordinator code — production coordinator uses `@caravan/clients` for its bitcoind / explorer calls — but the e2e harness kept the chain on the lockfile.

This PR swaps the e2e harness's `BitcoinCoreService` to call `callBitcoind(url, auth, method, params)` from `@caravan/clients` instead of `new BitcoinCore(...).command(method, ...args)`. Class API and method signatures are unchanged so the seven consumer files (smoke / mutate / verify specs, wallet setup, POM, fixture, setup-teardown) are untouched.

## Audit impact

| | Critical | High | Moderate | Low | Total |
| --- | --- | --- | --- | --- | --- |
| Before | 3 | 13 | 4 | 6 | 26 |
| After | 1 | 13 | 0 | 6 | **20** |

Cleared: `bitcoin-core`, `@uphold/request-logger`, `request`, `form-data`, `qs`, `tough-cookie`. Both remaining critical advisories (`form-data`, `request`) are removed.

## Changes

- `apps/coordinator/e2e/services/bitcoinServices.ts`: rewritten to call `callBitcoind` per RPC method. Wallet-scoped calls use `${baseUrl}/wallet/${walletName}` instead of the `{ wallet }` constructor option.
- `apps/coordinator/package.json`: removes `bitcoin-core: ^5.0.0`.
- `packages/caravan-clients/src/index.ts`: exports `callBitcoind` (previously only reachable via the internal `./bitcoind` subpath). Useful for any consumer talking directly to bitcoind.
- Changeset for `@caravan/clients` patch bump.

## Test plan

- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`
- [x] `npm run test:e2e` — **14/14 Playwright tests pass** against bitcoind regtest, validating every wrapped RPC method (`getblockchaininfo`, `createwallet`, `loadwallet`, `unloadwallet`, `listwallets`, `listdescriptors`, `getbalance`, `getnewaddress`, `getreceivedbyaddress`, `generatetoaddress`, `sendtoaddress`, `walletprocesspsbt`, `decodepsbt`)