### PR TITLE
fix: skip changeset validation on release PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
   validate-changesets:
     name: Validate Changesets
     runs-on: ubuntu-latest
+    # Skip on the automated "Version Packages" release PR: it consumes all
+    # changesets while bumping package versions, so `changeset status` would
+    # (correctly) report changed packages with no changesets and fail.
+    if: github.head_ref != 'changeset-release/main'
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Thank you for contributing to Caravan! Please provide the following details to help us review your pull request efficiently.
-->

**What kind of change does this PR introduce?**

bugfix to allow "Validate Changesets" job to success on "Version Packages" PRs. 

Without this fix, we'd see the following error in CI:

```
Run npx changeset status --since=origin/main
🦋  error Some packages have been changed but no changesets were found. Run `changeset add` to resolve this error.
🦋  error If this change doesn't need a release, run `changeset add --empty`.
Error: Process completed with exit code 1.
```

**Summary**

The auto-generated "Version Packages" PR (from changeset-release/main) consumes all changesets while bumping package versions, so `changeset status --since=origin/main` correctly reports changed packages with no changesets and fails. Skip the Validate Changesets job for that branch so the release PR can pass CI and merge.

**Does this PR introduce a breaking change?**

No

## Checklist
- [ ] I have tested my changes thoroughly.
- [ ] I have added or updated tests to cover my changes (if applicable).
- [ ] I have verified that test coverage meets or exceeds 95% (if applicable).
- [ ] I have run the test suite locally, and all tests pass.
- [ ] I have written tests for all new changes/features
- [ ] I have followed the project's coding style and conventions.
- [ ] I have created a changeset to document my changes (`` npm run changeset ``)
