### PR TITLE
ci: grant pull-requests write for e2e results comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,10 +90,10 @@ jobs:
     name: E2E Tests
     needs: check-e2e
     if: needs.check-e2e.outputs.should-run-e2e == 'true'
-    # Permissions required by EnricoMi/publish-unit-test-result-action:
+    # Minimal public-repo permissions required by
+    # EnricoMi/publish-unit-test-result-action:
     # https://github.com/EnricoMi/publish-unit-test-result-action#permissions
     permissions:
-      contents: read
       checks: write
       pull-requests: write
     uses: ./.github/workflows/e2e.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,8 @@ jobs:
     name: E2E Tests
     needs: check-e2e
     if: needs.check-e2e.outputs.should-run-e2e == 'true'
-    # The reusable workflow posts test results as a PR comment via
-    # EnricoMi/publish-unit-test-result-action, which needs pull-requests:
-    # write in addition to the checks: write granted at the workflow level.
+    # Permissions required by EnricoMi/publish-unit-test-result-action:
+    # https://github.com/EnricoMi/publish-unit-test-result-action#permissions
     permissions:
       contents: read
       checks: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,13 @@ jobs:
     name: E2E Tests
     needs: check-e2e
     if: needs.check-e2e.outputs.should-run-e2e == 'true'
+    # The reusable workflow posts test results as a PR comment via
+    # EnricoMi/publish-unit-test-result-action, which needs pull-requests:
+    # write in addition to the checks: write granted at the workflow level.
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/e2e.yml
 
   check-coordinator:


### PR DESCRIPTION
**What kind of change does this PR introduce?**

ci bugfix

**Summary**

 The E2E job calls the reusable `e2e.yml`, which posts test results as a PR comment via `EnricoMi/publish-unit-test-result-action`. The workflow only grants `contents: read` + `checks: write`, so the check run is created but the PR comment POST fails with `403 Resource not accessible by integration`, crashing the job (even though the tests themselves passed).

Minimum permissions: https://github.com/EnricoMi/publish-unit-test-result-action#permissions

## Checklist
- [ ] I have tested my changes thoroughly.
- [ ] I have added or updated tests to cover my changes (if applicable).
- [ ] I have verified that test coverage meets or exceeds 95% (if applicable).
- [ ] I have run the test suite locally, and all tests pass.
- [ ] I have written tests for all new changes/features
- [ ] I have followed the project's coding style and conventions.
- [ ] I have created a changeset to document my changes (`` npm run changeset ``)
