### PR TITLE
fix(wallets): handle Jade USB timeouts and multipart sign_psbt replies

### DIFF
--- a/.changeset/jade-usb-protocol.md
+++ b/.changeset/jade-usb-protocol.md
@@ -1,0 +1,5 @@
+---
+"@caravan/wallets": patch
+---
+
+Fix Jade USB address confirmation timeouts, multipart sign_psbt replies, and serial DTR/RTS handling so Classic devices can finish signing without hanging.

--- a/.changeset/tired-knives-own.md
+++ b/.changeset/tired-knives-own.md
@@ -1,0 +1,5 @@
+---
+"@caravan/wallets": patch
+---
+
+This patch fixes signing large PSBTs on Jade devices as the device break up the transaction into sequenced chunks and we were not supporting that. Also extends timeout time for confirming address on device.

--- a/packages/caravan-wallets/src/jade.ts
+++ b/packages/caravan-wallets/src/jade.ts
@@ -15,8 +15,6 @@ import {
 } from "@caravan/bitcoin";
 import {
   Jade,
-  JadeInterface,
-  SerialTransport,
   IJade,
   IJadeInterface,
   JadeTransport,
@@ -34,6 +32,8 @@ import {
   ACTIVE,
   INFO,
 } from "./interaction";
+import { JadeRpcInterface } from "./jadeRpc";
+import { JadeSerialTransport } from "./jadeSerial";
 import { MultisigWalletConfig } from "./types";
 
 export const JADE = "jade";
@@ -140,9 +140,10 @@ export class JadeInteraction extends DirectKeystoreInteraction {
     super();
     this.network = network ?? (DEFAULT_NETWORK as BitcoinNetwork);
 
-    // Dependency injections or default to an instance from jadets
-    this.transport = dependencies?.transport ?? new SerialTransport({}); 
-    this.ijade = dependencies?.jadeInterface ?? new JadeInterface(this.transport);
+    // jadets JadeInterface/SerialTransport mishandle timeouts, multipart
+    // sign_psbt replies, and DTR/RTS. Use Caravan wrappers by default.
+    this.transport = dependencies?.transport ?? new JadeSerialTransport({});
+    this.ijade = dependencies?.jadeInterface ?? new JadeRpcInterface(this.transport);
     this.jade = dependencies?.jade ?? new Jade(this.ijade);
   }
 

--- a/packages/caravan-wallets/src/jadeRpc.test.ts
+++ b/packages/caravan-wallets/src/jadeRpc.test.ts
@@ -1,0 +1,162 @@
+import { EventEmitter } from "events";
+
+import { JadeTransport, RPCRequest } from "jadets";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_JADE_RPC_TIMEOUT_MS, JadeRpcInterface } from "./jadeRpc";
+
+class MockTransport extends EventEmitter implements JadeTransport {
+  sent: RPCRequest[] = [];
+
+  connect(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  disconnect(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  sendMessage(msg: any): Promise<void> {
+    this.sent.push(msg);
+    return Promise.resolve();
+  }
+
+  onMessage(callback: (msg: any) => void): void {
+    this.on("message", callback);
+  }
+}
+
+describe("JadeRpcInterface", () => {
+  let transport: MockTransport;
+  let rpc: JadeRpcInterface;
+
+  beforeEach(() => {
+    transport = new MockTransport();
+    rpc = new JadeRpcInterface(transport);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns a single-fragment reply", async () => {
+    const pending = rpc.makeRPCCall({ id: "1", method: "ping" });
+    await vi.waitFor(() => expect(transport.sent).toHaveLength(1));
+    transport.emit("message", { id: "1", result: 0 });
+    await expect(pending).resolves.toEqual({ id: "1", result: 0 });
+  });
+
+  it("does not time out at 5 seconds", async () => {
+    vi.useFakeTimers();
+    const pending = rpc.makeRPCCall({ id: "1", method: "ping" });
+    let settled = false;
+    pending.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_JADE_RPC_TIMEOUT_MS - 5000);
+    await expect(pending).rejects.toThrow("RPC call timed out");
+  });
+
+  it("does not time out get_receive_address while the user reviews the device", async () => {
+    vi.useFakeTimers();
+    const pending = rpc.makeRPCCall({
+      id: "addr",
+      method: "get_receive_address",
+      params: { network: "mainnet" },
+    });
+    let settled = false;
+    pending.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_JADE_RPC_TIMEOUT_MS + 1000);
+    expect(settled).toBe(false);
+
+    transport.emit("message", { id: "addr", result: "bc1qtest" });
+    await expect(pending).resolves.toEqual({
+      id: "addr",
+      result: "bc1qtest",
+    });
+  });
+
+  it("collects every sign_psbt fragment including the last", async () => {
+    const pending = rpc.makeRPCCall(
+      { id: "orig", method: "sign_psbt", params: { network: "mainnet" } },
+      true,
+    );
+    await vi.waitFor(() => expect(transport.sent).toHaveLength(1));
+
+    transport.emit("message", {
+      id: "orig",
+      seqnum: 1,
+      seqlen: 3,
+      result: new Uint8Array([1]),
+    });
+
+    await vi.waitFor(() => expect(transport.sent).toHaveLength(2));
+    const firstExtended = transport.sent[1];
+    expect(firstExtended.method).toBe("get_extended_data");
+    expect(firstExtended.id).not.toBe("orig");
+    expect(firstExtended.params).toEqual({
+      origid: "orig",
+      orig: "sign_psbt",
+      seqnum: 2,
+      seqlen: 3,
+    });
+
+    transport.emit("message", {
+      id: firstExtended.id,
+      seqnum: 2,
+      seqlen: 3,
+      result: new Uint8Array([2]),
+    });
+
+    await vi.waitFor(() => expect(transport.sent).toHaveLength(3));
+    const secondExtended = transport.sent[2];
+    expect(secondExtended.params).toEqual({
+      origid: "orig",
+      orig: "sign_psbt",
+      seqnum: 3,
+      seqlen: 3,
+    });
+
+    transport.emit("message", {
+      id: secondExtended.id,
+      seqnum: 3,
+      seqlen: 3,
+      result: new Uint8Array([3]),
+    });
+
+    const reply = await pending;
+    expect(reply.id).toBe("orig");
+    expect(Array.from(reply.result as Uint8Array)).toEqual([1, 2, 3]);
+  });
+
+  it("does not request extra fragments when seqnum equals seqlen", async () => {
+    const pending = rpc.makeRPCCall({ id: "orig", method: "sign_psbt" }, true);
+    await vi.waitFor(() => expect(transport.sent).toHaveLength(1));
+    transport.emit("message", {
+      id: "orig",
+      seqnum: 1,
+      seqlen: 1,
+      result: new Uint8Array([9]),
+    });
+    const reply = await pending;
+    expect(transport.sent).toHaveLength(1);
+    expect(Array.from(reply.result as Uint8Array)).toEqual([9]);
+  });
+});

--- a/packages/caravan-wallets/src/jadeRpc.ts
+++ b/packages/caravan-wallets/src/jadeRpc.ts
@@ -1,0 +1,199 @@
+/**
+ * Jade RPC client that matches Blockstream's documented serial protocol.
+ *
+ * jadets 1.1.20 times out user-facing calls after 5s and mishandles
+ * multipart `sign_psbt` replies. This interface is the default used by
+ * Caravan Jade interactions.
+ *
+ * See https://github.com/Blockstream/Jade/blob/master/docs/index.rst
+ */
+
+import { IJadeInterface, JadeTransport, RPCRequest, RPCResponse } from "jadets";
+
+/** jadepy default serial timeout, in milliseconds. */
+export const DEFAULT_JADE_RPC_TIMEOUT_MS = 120000;
+
+/**
+ * RPCs that wait on device-button confirmation. jadets does not pass
+ * `long_timeout` for `get_receive_address`; we do, so address review
+ * cannot hit the default timeout.
+ */
+const USER_INTERACTIVE_METHODS = new Set(["get_receive_address"]);
+
+function nextRequestId(): string {
+  return Math.floor(Math.random() * 1000000).toString();
+}
+
+function concatenateByteChunks(chunks: RPCResponse[]): Uint8Array {
+  const parts = chunks.map((chunk) => {
+    const { result } = chunk;
+    if (result instanceof Uint8Array) {
+      return result;
+    }
+    if (typeof Buffer !== "undefined" && Buffer.isBuffer(result)) {
+      return new Uint8Array(result);
+    }
+    throw new Error("Jade extended data chunk was not binary");
+  });
+  const totalLength = parts.reduce((sum, part) => sum + part.length, 0);
+  const merged = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const part of parts) {
+    merged.set(part, offset);
+    offset += part.length;
+  }
+  return merged;
+}
+
+export class JadeRpcInterface implements IJadeInterface {
+  private transport: JadeTransport;
+
+  constructor(transport: JadeTransport) {
+    this.transport = transport;
+  }
+
+  async connect(): Promise<void> {
+    await this.transport.connect();
+  }
+
+  async disconnect(): Promise<void> {
+    await this.transport.disconnect();
+  }
+
+  buildRequest(id: string, method: string, params?: any): RPCRequest {
+    return { id, method, params };
+  }
+
+  async makeRPCCall(
+    request: RPCRequest,
+    longTimeout = false,
+  ): Promise<RPCResponse> {
+    if (!request.id || request.id.length > 16) {
+      throw new Error(
+        "Request id must be non-empty and less than 16 characters",
+      );
+    }
+    if (!request.method || request.method.length > 32) {
+      throw new Error(
+        "Request method must be non-empty and less than 32 characters",
+      );
+    }
+
+    const waitWithoutTimeout =
+      longTimeout || USER_INTERACTIVE_METHODS.has(request.method);
+
+    await this.transport.sendMessage(request);
+    const initialResponse = await this.waitForResponse(
+      request.id,
+      waitWithoutTimeout,
+    );
+
+    if (this.needsMoreFragments(initialResponse)) {
+      return this.collectExtendedData(
+        initialResponse,
+        request,
+        waitWithoutTimeout,
+      );
+    }
+
+    return initialResponse;
+  }
+
+  private waitForResponse(
+    requestId: string,
+    waitWithoutTimeout: boolean,
+  ): Promise<RPCResponse> {
+    return new Promise((resolve, reject) => {
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+      const onResponse = (msg: RPCResponse) => {
+        if (!msg || msg.id !== requestId) {
+          return;
+        }
+        this.transport.removeListener("message", onResponse);
+        if (timeoutId !== null) {
+          clearTimeout(timeoutId);
+        }
+        resolve(msg);
+      };
+
+      this.transport.onMessage(onResponse);
+
+      if (!waitWithoutTimeout) {
+        timeoutId = setTimeout(() => {
+          this.transport.removeListener("message", onResponse);
+          reject(new Error("RPC call timed out"));
+        }, DEFAULT_JADE_RPC_TIMEOUT_MS);
+      }
+    });
+  }
+
+  /**
+   * Jade seqnum is 1-based. More fragments exist while seqnum < seqlen.
+   */
+  private needsMoreFragments(response: RPCResponse): boolean {
+    return (
+      typeof response.seqnum === "number" &&
+      typeof response.seqlen === "number" &&
+      response.seqnum < response.seqlen
+    );
+  }
+
+  /**
+   * Fetch remaining `sign_psbt` fragments per Jade's get_extended_data
+   * request: new id, origid, orig, seqnum, seqlen.
+   */
+  private async collectExtendedData(
+    initialResponse: RPCResponse,
+    originalRequest: RPCRequest,
+    waitWithoutTimeout: boolean,
+  ): Promise<RPCResponse> {
+    const chunks = [initialResponse];
+    let last = initialResponse;
+
+    // Fragments must be requested in order; Jade will not pipeline them.
+    /* eslint-disable no-await-in-loop */
+    while (this.needsMoreFragments(last)) {
+      const nextSeqnum = (last.seqnum as number) + 1;
+      const extendedRequest = this.buildRequest(
+        nextRequestId(),
+        "get_extended_data",
+        {
+          origid: originalRequest.id,
+          orig: originalRequest.method,
+          seqnum: nextSeqnum,
+          seqlen: last.seqlen,
+        },
+      );
+      await this.transport.sendMessage(extendedRequest);
+      const chunk = await this.waitForResponse(
+        extendedRequest.id,
+        waitWithoutTimeout,
+      );
+
+      if (chunk.error) {
+        return chunk;
+      }
+      if (chunk.seqnum !== nextSeqnum) {
+        throw new Error(
+          `Expected Jade fragment ${nextSeqnum}, got ${String(chunk.seqnum)}`,
+        );
+      }
+      if (chunk.seqlen !== last.seqlen) {
+        throw new Error(
+          `Inconsistent Jade seqlen: expected ${String(last.seqlen)}, got ${String(chunk.seqlen)}`,
+        );
+      }
+
+      chunks.push(chunk);
+      last = chunk;
+    }
+    /* eslint-enable no-await-in-loop */
+
+    return {
+      id: originalRequest.id,
+      error: chunks[0].error,
+      result: concatenateByteChunks(chunks),
+    };
+  }
+}

--- a/packages/caravan-wallets/src/jadeSerial.test.ts
+++ b/packages/caravan-wallets/src/jadeSerial.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { setSignals } = vi.hoisted(() => ({
+  setSignals: vi.fn().mockResolvedValue(),
+}));
+
+vi.mock("jadets", () => {
+  class SerialTransport {
+    port: { setSignals: typeof setSignals } | null = null;
+
+    async connect() {
+      this.port = { setSignals };
+    }
+  }
+
+  return { SerialTransport };
+});
+
+import { JadeSerialTransport } from "./jadeSerial";
+
+describe("JadeSerialTransport", () => {
+  beforeEach(() => {
+    setSignals.mockClear();
+  });
+
+  it("clears DTR and RTS after the serial port opens", async () => {
+    const transport = new JadeSerialTransport({});
+    await transport.connect();
+    expect(setSignals).toHaveBeenCalledWith({
+      dataTerminalReady: false,
+      requestToSend: false,
+    });
+  });
+});

--- a/packages/caravan-wallets/src/jadeSerial.ts
+++ b/packages/caravan-wallets/src/jadeSerial.ts
@@ -1,0 +1,37 @@
+/**
+ * Web Serial transport for Jade.
+ *
+ * Jade Classic reboots if DTR/RTS stay asserted after the port opens.
+ * jadepy clears both lines; jadets SerialTransport does not.
+ */
+
+import { SerialTransport } from "jadets";
+
+type SerialPortSignals = {
+  setSignals?: (signals: {
+    dataTerminalReady: boolean;
+    requestToSend: boolean;
+  }) => Promise<void>;
+};
+
+export class JadeSerialTransport extends SerialTransport {
+  async connect(): Promise<void> {
+    await super.connect();
+    await this.clearHardwareFlowControl();
+  }
+
+  private async clearHardwareFlowControl(): Promise<void> {
+    const port = (this as unknown as { port?: SerialPortSignals }).port;
+    if (!port || typeof port.setSignals !== "function") {
+      return;
+    }
+    try {
+      await port.setSignals({
+        dataTerminalReady: false,
+        requestToSend: false,
+      });
+    } catch (error) {
+      console.warn("Jade serial setSignals failed:", error);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `jadets` times out `getReceiveAddress` after 5 seconds. Official `jadepy` waits 120s. Classic devices often need the extra time to confirm a change address.
- Multipart `sign_psbt` replies are 1-based. `jadets` skips the last fragment and omits `origid` / `orig` / `seqlen` on `get_extended_data`, so Jade stays on Processing and the host never gets a signature.
- After opening serial, clear DTR/RTS the same way `jadepy` does. Leaving them set can reboot Jade Classic.

Caravan now wraps serial + RPC instead of forking `jadets`. Unchained will pick this up after `@caravan/wallets` is published and bumped.

## Test plan
- [ ] Confirm a receive/change address on Jade Classic over USB. It should not time out at 5 seconds.
- [ ] Sign a PSBT over USB on Jade Classic. Jade should leave Processing and return a signed PSBT.
- [ ] Open the serial connection and confirm the device does not reboot.
- [ ] Run `packages/caravan-wallets` Jade unit tests (`jadeRpc`, `jadeSerial`, existing `jade` tests).


Made with [Cursor](https://cursor.com)